### PR TITLE
Updated tree-sitter, added clarification regarding the build process to Readme, added test script entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is quite slow and can take up to one or two hours but can provide good resu
 
 #### Install required build tools:
 
--   This project is based upon Node.js. Therefore, there has to be a recent version of Node.js installed on your machine (Version 18 or newer).
+-   This project is based upon Node.js. Therefore, there has to be a recent version of Node.js installed on your machine (version 18 or newer).
 -   Ensure that you have installed all build tools necessary to compile the native C/C++ parts of the required tree-sitter package: https://github.com/nodejs/node-gyp#installation
 
 #### Install project and parse your sources:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is quite slow and can take up to one or two hours but can provide good resu
 
 #### Install required build tools:
 
-Ensure that you have installed all build tools necessary to compile the native C++ parts of the required tree-sitter package: https://github.com/nodejs/node-gyp#installation
+Ensure that you have installed all build tools necessary to compile the native parts of the required tree-sitter package: https://github.com/nodejs/node-gyp#installation
 
 #### Install project and parse your sources:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is quite slow and can take up to one or two hours but can provide good resu
 
 #### Install required build tools:
 
-Ensure that you have installed all build tools necessary to compile the native parts of the required tree-sitter package: https://github.com/nodejs/node-gyp#installation
+Ensure that you have installed all build tools necessary to compile the native C/C++ parts of the required tree-sitter package: https://github.com/nodejs/node-gyp#installation
 
 #### Install project and parse your sources:
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is quite slow and can take up to one or two hours but can provide good resu
 
 #### Install required build tools:
 
--   This project is based upon Node.js. Therefore, there has to be a recent version of Node.js installed on your machine.
+-   This project is based upon Node.js. Therefore, there has to be a recent version of Node.js installed on your machine (Version 18 or newer).
 -   Ensure that you have installed all build tools necessary to compile the native C/C++ parts of the required tree-sitter package: https://github.com/nodejs/node-gyp#installation
 
 #### Install project and parse your sources:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ This is quite slow and can take up to one or two hours but can provide good resu
 
 #### Install required build tools:
 
-Ensure that you have installed all build tools necessary to compile the native C/C++ parts of the required tree-sitter package: https://github.com/nodejs/node-gyp#installation
+-   This project is based upon Node.js. Therefore, there has to be a recent version of Node.js installed on your machine.
+-   Ensure that you have installed all build tools necessary to compile the native C/C++ parts of the required tree-sitter package: https://github.com/nodejs/node-gyp#installation
 
 #### Install project and parse your sources:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This is quite slow and can take up to one or two hours but can provide good resu
 
 ### Usage
 
+#### Install required build tools:
+
+Ensure that you have installed all build tools necessary to compile the native C++ parts of the required tree-sitter package: https://github.com/nodejs/node-gyp#installation
+
 #### Install project and parse your sources:
 
 -   `npm install`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is quite slow and can take up to one or two hours but can provide good resu
 
 #### Install required build tools:
 
--   This project is based upon Node.js. Therefore, there has to be a recent version of Node.js installed on your machine (version 18 or newer).
+-   This project is based upon Node.js. Therefore, there has to be a recent version of Node.js installed on your machine (see `engines` entry of package.json for version requirements).
 -   Ensure that you have installed all build tools necessary to compile the native C/C++ parts of the required tree-sitter package: https://github.com/nodejs/node-gyp#installation
 
 #### Install project and parse your sources:

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,9 @@
                 "prettier": "^2.4.1",
                 "pretty-quick": "^3.1.1",
                 "typescript": "^4.4.4"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "metric-gardener",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "metric-gardener",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "dependencies": {
                 "copyfiles": "^2.4.1",
                 "javascript-lp-solver": "^0.4.24",
-                "tree-sitter": "^0.20.0",
+                "tree-sitter": "^0.20.6",
                 "tree-sitter-c-sharp": "^0.19.0",
                 "tree-sitter-cpp": "^0.20.0",
                 "tree-sitter-go": "^0.19.1",
@@ -2699,21 +2699,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/tsutils": {
             "version": "3.21.0",
             "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -2835,21 +2820,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/tsutils": {
@@ -3007,14 +2977,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/ansi-styles": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -3038,20 +3000,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/aproba": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-        },
-        "node_modules/are-we-there-yet": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-            "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-            "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
             }
         },
         "node_modules/argparse": {
@@ -3384,9 +3332,9 @@
             }
         },
         "node_modules/bl/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -3733,14 +3681,6 @@
                 "node": ">= 0.12.0"
             }
         },
-        "node_modules/code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/collect-v8-coverage": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -3793,11 +3733,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "node_modules/console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "node_modules/convert-source-map": {
             "version": "1.8.0",
@@ -4003,14 +3938,17 @@
             "dev": true
         },
         "node_modules/decompress-response": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
             "dependencies": {
-                "mimic-response": "^2.0.0"
+                "mimic-response": "^3.1.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/dedent": {
@@ -4063,20 +4001,12 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
         "node_modules/detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "bin": {
-                "detect-libc": "bin/detect-libc.js"
-            },
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+            "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
             "engines": {
-                "node": ">=0.10"
+                "node": ">=8"
             }
         },
         "node_modules/detect-newline": {
@@ -4561,21 +4491,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/eslint/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/eslint/node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4944,21 +4859,6 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
-        "node_modules/gauge": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "dependencies": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            }
-        },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5014,7 +4914,7 @@
         "node_modules/github-from-package": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
         },
         "node_modules/glob": {
             "version": "7.2.0",
@@ -5114,11 +5014,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "node_modules/html-encoding-sniffer": {
             "version": "2.0.1",
@@ -5330,17 +5225,6 @@
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6996,21 +6880,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/jest-snapshot/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/jest-snapshot/node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7827,7 +7696,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -7927,11 +7795,11 @@
             }
         },
         "node_modules/mimic-response": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-            "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -8001,9 +7869,9 @@
             }
         },
         "node_modules/nan": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-            "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+            "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
         },
         "node_modules/napi-build-utils": {
             "version": "1.0.2",
@@ -8017,11 +7885,14 @@
             "dev": true
         },
         "node_modules/node-abi": {
-            "version": "2.30.1",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-            "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+            "version": "3.52.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
+            "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
             "dependencies": {
-                "semver": "^5.4.1"
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/node-int64": {
@@ -8096,38 +7967,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/npmlog": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "dependencies": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-            }
-        },
-        "node_modules/number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/nwsapi": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
             "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
             "dev": true
-        },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/object-inspect": {
             "version": "1.11.0",
@@ -8376,21 +8220,20 @@
             }
         },
         "node_modules/prebuild-install": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-            "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+            "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
             "dependencies": {
-                "detect-libc": "^1.0.3",
+                "detect-libc": "^2.0.0",
                 "expand-template": "^2.0.3",
                 "github-from-package": "0.0.0",
                 "minimist": "^1.2.3",
                 "mkdirp-classic": "^0.5.3",
                 "napi-build-utils": "^1.0.1",
-                "node-abi": "^2.21.0",
-                "npmlog": "^4.0.1",
+                "node-abi": "^3.3.0",
                 "pump": "^3.0.0",
                 "rc": "^1.2.7",
-                "simple-get": "^3.0.3",
+                "simple-get": "^4.0.0",
                 "tar-fs": "^2.0.0",
                 "tunnel-agent": "^0.6.0"
             },
@@ -8398,7 +8241,7 @@
                 "prebuild-install": "bin.js"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">=10"
             }
         },
         "node_modules/prelude-ls": {
@@ -8940,17 +8783,18 @@
             }
         },
         "node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
             "bin": {
-                "semver": "bin/semver"
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
-        },
-        "node_modules/set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -8976,7 +8820,8 @@
         "node_modules/signal-exit": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-            "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ=="
+            "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+            "dev": true
         },
         "node_modules/simple-concat": {
             "version": "1.0.1",
@@ -8998,11 +8843,25 @@
             ]
         },
         "node_modules/simple-get": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-            "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
             "dependencies": {
-                "decompress-response": "^4.2.0",
+                "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
                 "simple-concat": "^1.0.0"
             }
@@ -9159,30 +9018,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/strip-bom": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -9204,7 +9039,7 @@
         "node_modules/strip-json-comments": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9288,9 +9123,9 @@
             }
         },
         "node_modules/tar-stream/node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -9411,13 +9246,13 @@
             }
         },
         "node_modules/tree-sitter": {
-            "version": "0.20.0",
-            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.0.tgz",
-            "integrity": "sha512-tqTdtD1T2cN4aEES0sZCjKTQrc9Ls8H/iYlzpskhGy8yCwNPKBIbK9YuuCg/AxACr8RAY4wMoeCigM1X/A79yg==",
+            "version": "0.20.6",
+            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.6.tgz",
+            "integrity": "sha512-GxJodajVpfgb3UREzzIbtA1hyRnTxVbWVXrbC6sk4xTMH5ERMBJk9HJNq4c8jOJeUaIOmLcwg+t6mez/PDvGqg==",
             "hasInstallScript": true,
             "dependencies": {
-                "nan": "^2.14.0",
-                "prebuild-install": "^6.0.1"
+                "nan": "^2.18.0",
+                "prebuild-install": "^7.1.1"
             }
         },
         "node_modules/tree-sitter-c-sharp": {
@@ -9510,7 +9345,7 @@
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -9756,14 +9591,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/wide-align": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-            "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-            "dependencies": {
-                "string-width": "^1.0.2 || 2 || 3 || 4"
-            }
-        },
         "node_modules/word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -9928,8 +9755,7 @@
         "node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yaml": {
             "version": "1.10.2",
@@ -11952,15 +11778,6 @@
                 "tsutils": "^3.21.0"
             },
             "dependencies": {
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
                 "tsutils": {
                     "version": "3.21.0",
                     "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -12029,15 +11846,6 @@
                 "tsutils": "^3.21.0"
             },
             "dependencies": {
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
                 "tsutils": {
                     "version": "3.21.0",
                     "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -12148,11 +11956,6 @@
                 "type-fest": "^0.21.3"
             }
         },
-        "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
         "ansi-styles": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -12170,20 +11973,6 @@
             "requires": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
-            }
-        },
-        "aproba": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-        },
-        "are-we-there-yet": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-            "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-            "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
             }
         },
         "argparse": {
@@ -12436,9 +12225,9 @@
             },
             "dependencies": {
                 "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "version": "3.6.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+                    "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -12687,11 +12476,6 @@
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
             "dev": true
         },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
         "collect-v8-coverage": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -12738,11 +12522,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "convert-source-map": {
             "version": "1.8.0",
@@ -12908,11 +12687,11 @@
             "dev": true
         },
         "decompress-response": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
             "requires": {
-                "mimic-response": "^2.0.0"
+                "mimic-response": "^3.1.0"
             }
         },
         "dedent": {
@@ -12953,15 +12732,10 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
         },
-        "delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
         "detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+            "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
         },
         "detect-newline": {
             "version": "3.1.0",
@@ -13244,15 +13018,6 @@
                     "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
                     "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
                     "dev": true
-                },
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
                 },
                 "strip-ansi": {
                     "version": "6.0.1",
@@ -13599,21 +13364,6 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
-        "gauge": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            }
-        },
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -13651,7 +13401,7 @@
         "github-from-package": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
         },
         "glob": {
             "version": "7.2.0",
@@ -13721,11 +13471,6 @@
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
             "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
             "dev": true
-        },
-        "has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "html-encoding-sniffer": {
             "version": "2.0.1",
@@ -13874,14 +13619,6 @@
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
             "dev": true
-        },
-        "is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "requires": {
-                "number-is-nan": "^1.0.0"
-            }
         },
         "is-generator-fn": {
             "version": "2.1.0",
@@ -15128,15 +14865,6 @@
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
                 "supports-color": {
                     "version": "7.2.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -15745,7 +15473,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
             "requires": {
                 "yallist": "^4.0.0"
             }
@@ -15820,9 +15547,9 @@
             "dev": true
         },
         "mimic-response": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-            "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
         },
         "minimatch": {
             "version": "3.0.4",
@@ -15873,9 +15600,9 @@
             }
         },
         "nan": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-            "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+            "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
         },
         "napi-build-utils": {
             "version": "1.0.2",
@@ -15889,11 +15616,11 @@
             "dev": true
         },
         "node-abi": {
-            "version": "2.30.1",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-            "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+            "version": "3.52.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
+            "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
             "requires": {
-                "semver": "^5.4.1"
+                "semver": "^7.3.5"
             }
         },
         "node-int64": {
@@ -15961,32 +15688,11 @@
                 "path-key": "^3.0.0"
             }
         },
-        "npmlog": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-            }
-        },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
         "nwsapi": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
             "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
             "dev": true
-        },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-inspect": {
             "version": "1.11.0",
@@ -16163,21 +15869,20 @@
             }
         },
         "prebuild-install": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-            "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+            "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
             "requires": {
-                "detect-libc": "^1.0.3",
+                "detect-libc": "^2.0.0",
                 "expand-template": "^2.0.3",
                 "github-from-package": "0.0.0",
                 "minimist": "^1.2.3",
                 "mkdirp-classic": "^0.5.3",
                 "napi-build-utils": "^1.0.1",
-                "node-abi": "^2.21.0",
-                "npmlog": "^4.0.1",
+                "node-abi": "^3.3.0",
                 "pump": "^3.0.0",
                 "rc": "^1.2.7",
-                "simple-get": "^3.0.3",
+                "simple-get": "^4.0.0",
                 "tar-fs": "^2.0.0",
                 "tunnel-agent": "^0.6.0"
             }
@@ -16577,14 +16282,12 @@
             }
         },
         "semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
-        "set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "requires": {
+                "lru-cache": "^6.0.0"
+            }
         },
         "shebang-command": {
             "version": "2.0.0",
@@ -16604,7 +16307,8 @@
         "signal-exit": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-            "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ=="
+            "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+            "dev": true
         },
         "simple-concat": {
             "version": "1.0.1",
@@ -16612,11 +16316,11 @@
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
         },
         "simple-get": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-            "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
             "requires": {
-                "decompress-response": "^4.2.0",
+                "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
                 "simple-concat": "^1.0.0"
             }
@@ -16737,24 +16441,6 @@
                 }
             }
         },
-        "string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            }
-        },
-        "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "requires": {
-                "ansi-regex": "^2.0.0"
-            }
-        },
         "strip-bom": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -16770,7 +16456,7 @@
         "strip-json-comments": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
         },
         "supports-color": {
             "version": "5.5.0",
@@ -16838,9 +16524,9 @@
             },
             "dependencies": {
                 "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "version": "3.6.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+                    "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -16939,12 +16625,12 @@
             }
         },
         "tree-sitter": {
-            "version": "0.20.0",
-            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.0.tgz",
-            "integrity": "sha512-tqTdtD1T2cN4aEES0sZCjKTQrc9Ls8H/iYlzpskhGy8yCwNPKBIbK9YuuCg/AxACr8RAY4wMoeCigM1X/A79yg==",
+            "version": "0.20.6",
+            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.6.tgz",
+            "integrity": "sha512-GxJodajVpfgb3UREzzIbtA1hyRnTxVbWVXrbC6sk4xTMH5ERMBJk9HJNq4c8jOJeUaIOmLcwg+t6mez/PDvGqg==",
             "requires": {
-                "nan": "^2.14.0",
-                "prebuild-install": "^6.0.1"
+                "nan": "^2.18.0",
+                "prebuild-install": "^7.1.1"
             }
         },
         "tree-sitter-c-sharp": {
@@ -17028,7 +16714,7 @@
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -17215,14 +16901,6 @@
                 "isexe": "^2.0.0"
             }
         },
-        "wide-align": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-            "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-            "requires": {
-                "string-width": "^1.0.2 || 2 || 3 || 4"
-            }
-        },
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -17339,8 +17017,7 @@
         "yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yaml": {
             "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "description": "A tool to calculate metrics for imperative and object-oriented languages",
     "main": "dist/app.js",
     "bin": "dist/app.js",
+    "engines": {
+        "node": ">=18"
+    },
     "scripts": {
         "start": "tsc && node dist/app.js",
         "test": "jest",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "copyfiles": "^2.4.1",
         "javascript-lp-solver": "^0.4.24",
-        "tree-sitter": "^0.20.0",
+        "tree-sitter": "^0.20.6",
         "tree-sitter-c-sharp": "^0.19.0",
         "tree-sitter-cpp": "^0.20.0",
         "tree-sitter-go": "^0.19.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "bin": "dist/app.js",
     "scripts": {
         "start": "tsc && node dist/app.js",
+        "test": "jest",
         "format": "prettier --write \"./**/*\"",
         "format:quick": "pretty-quick --staged",
         "lint": "eslint \"src/**/*.ts\"",

--- a/src/parser/CouplingCalculator.ts
+++ b/src/parser/CouplingCalculator.ts
@@ -19,7 +19,7 @@ export class CouplingCalculator {
         this.config = configuration;
 
         const nodeTypesJson = fs
-            .readFileSync(fs.realpathSync("./resources/node-types-mapped.config"))
+            .readFileSync(fs.realpathSync("./src/parser/config/nodeTypesConfig.json"))
             .toString();
         const allNodeTypes: ExpressionMetricMapping[] = JSON.parse(nodeTypesJson);
 


### PR DESCRIPTION
Updated to tree-sitter 0.20.6, which is the latest version of tree-sitter at the time of this pull request, runs now with Node 20.10.0 (LTS).

I have added a test script entry in package.json that runs "jest" in order for "npm test" to work. This should be changed to the new method once #20 is implemented.

Added entry for the supported node version in package.json