### PR TITLE
Replaced most console.log outputs with conditional debuglog outputs, added some documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ One parser for all languages!
 No need to build your source code.
 This static source code parser calculates simple software quality metrics for quite a few languages (more will be added).
 
-
 An experimental approach is implemented to approximate couplings metrics for C# and PHP without you having to build the source code.
 This is quite slow and can take up to one or two hours but can provide good results.
 
@@ -84,6 +83,11 @@ For this, reimport grammars for supported languages from tree-sitter by:
 -   `npm run start -- import-grammars`
 
 This will have no effect until you have mapped the changed and new expressions manually to ./src/parser/config/nodeTypesConfig.json
+
+### Enable debug prints
+
+There are additional outputs about the metric calculation process that can be enabled by setting the
+environment variable `NODE_DEBUG` to `metric-gardener`.
 
 ### TODOs
 

--- a/src/parser/Configuration.ts
+++ b/src/parser/Configuration.ts
@@ -1,11 +1,46 @@
+/**
+ * Configures the files to be parsed and the metrics to be calculated.
+ */
 export class Configuration {
+    /**
+     * Path to the source files to be parsed.
+     */
     sourcesPath: string;
+
+    /**
+     * Path where the output file with the calculated metrics should be stored.
+     */
     outputPath: string;
+
+    /**
+     * Whether dependencies should be analyzed.
+     */
     parseMetrics: boolean;
+
+    /**
+     * Folders to exclude from being searched for files to be parsed.
+     */
     parseDependencies: boolean;
+
+    /**
+     * Folders to exclude from being searched for files to be parsed.
+     */
     exclusions: string[];
+
+    /**
+     * Whether to compress the output file with the calculated metrics in a zip archive.
+     */
     compress: boolean;
 
+    /**
+     * Constructs a new {@link Configuration} object by specifying the files to be parsed
+     * and the metrics to be calculated.
+     * @param sourcesPath Path to the source files to be parsed.
+     * @param outputPath Path where the output file with the calculated metrics should be stored.
+     * @param parseDependencies Whether dependencies should be analyzed.
+     * @param exclusions Folders to exclude from being searched for files to be parsed.
+     * @param compress Whether to compress the output file with the calculated metrics in a zip archive.
+     */
     constructor(
         sourcesPath: string,
         outputPath: string,

--- a/src/parser/CouplingCalculator.ts
+++ b/src/parser/CouplingCalculator.ts
@@ -6,9 +6,11 @@ import { NamespaceCollector } from "./resolver/NamespaceCollector";
 import { UsagesCollector } from "./resolver/UsagesCollector";
 import { CouplingMetric, ParseFile } from "./metrics/Metric";
 import { PublicAccessorCollector } from "./resolver/PublicAccessorCollector";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export class CouplingCalculator {
     private readonly comprisingMetrics: CouplingMetric[] = [];

--- a/src/parser/CouplingCalculator.ts
+++ b/src/parser/CouplingCalculator.ts
@@ -6,6 +6,9 @@ import { NamespaceCollector } from "./resolver/NamespaceCollector";
 import { UsagesCollector } from "./resolver/UsagesCollector";
 import { CouplingMetric, ParseFile } from "./metrics/Metric";
 import { PublicAccessorCollector } from "./resolver/PublicAccessorCollector";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export class CouplingCalculator {
     private readonly comprisingMetrics: CouplingMetric[] = [];
@@ -40,11 +43,11 @@ export class CouplingCalculator {
     calculateMetrics(parseFiles: ParseFile[]) {
         const sourcesRoot = fs.realpathSync(this.config.sourcesPath);
 
-        console.log("\n\n");
-        console.log("----- Parsing Coupling of files in " + sourcesRoot + " recursively -----");
-        console.log("\n\n");
+        dlog("\n\n");
+        dlog("----- Parsing Coupling of files in " + sourcesRoot + " recursively -----");
+        dlog("\n\n");
 
-        console.log(" --- " + parseFiles.length + " files detected", "\n\n");
+        dlog(" --- " + parseFiles.length + " files detected", "\n\n");
 
         // TODO rewrite this to support multiple coupling metrics
         return this.comprisingMetrics[0].calculate(parseFiles);

--- a/src/parser/GenericParser.ts
+++ b/src/parser/GenericParser.ts
@@ -5,6 +5,9 @@ import { Configuration } from "./Configuration";
 import { MetricCalculator } from "./MetricCalculator";
 import { CouplingCalculator } from "./CouplingCalculator";
 import { CouplingResult, MetricResult } from "./metrics/Metric";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export class GenericParser {
     private readonly config: Configuration;
@@ -23,7 +26,7 @@ export class GenericParser {
             []
         );
 
-        console.log(" --- " + parseFiles.length + " files detected", "\n\n");
+        dlog(" --- " + parseFiles.length + " files detected\n\n");
 
         let fileMetrics = new Map<string, Map<string, MetricResult>>();
         if (this.config.parseMetrics) {

--- a/src/parser/GenericParser.ts
+++ b/src/parser/GenericParser.ts
@@ -5,9 +5,11 @@ import { Configuration } from "./Configuration";
 import { MetricCalculator } from "./MetricCalculator";
 import { CouplingCalculator } from "./CouplingCalculator";
 import { CouplingResult, MetricResult } from "./metrics/Metric";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 /**
  * Arranges the parsing of files and calculation of metrics as specified by the stored configuration.

--- a/src/parser/GenericParser.ts
+++ b/src/parser/GenericParser.ts
@@ -9,13 +9,28 @@ import { debuglog } from "node:util";
 
 const dlog = debuglog("metric-gardener");
 
+/**
+ * Arranges the parsing of files and calculation of metrics as specified by the stored configuration.
+ */
 export class GenericParser {
+    /**
+     * Configuration according to which files are parsed and metrics are calculated.
+     * @private
+     */
     private readonly config: Configuration;
 
+    /**
+     * Constructs a new {@link GenericParser} object with the supplied configuration applied
+     * (see also {@link Configuration}).
+     * @param configuration The configuration to apply for the new {@link GenericParser} object.
+     */
     constructor(configuration: Configuration) {
         this.config = configuration;
     }
 
+    /**
+     * Parses files and calculates metrics as specified by the configuration of this {@link GenericParser} object.
+     */
     calculateMetrics() {
         const startTime = performance.now();
 

--- a/src/parser/MetricCalculator.ts
+++ b/src/parser/MetricCalculator.ts
@@ -9,9 +9,11 @@ import { ExpressionMetricMapping } from "./helper/Model";
 import { Configuration } from "./Configuration";
 import { Metric, MetricResult, ParseFile } from "./metrics/Metric";
 import nodeTypesConfig from "./config/nodeTypesConfig.json";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export class MetricCalculator {
     private readonly fileMetrics: Metric[] = [];

--- a/src/parser/MetricCalculator.ts
+++ b/src/parser/MetricCalculator.ts
@@ -9,6 +9,9 @@ import { ExpressionMetricMapping } from "./helper/Model";
 import { Configuration } from "./Configuration";
 import { Metric, MetricResult, ParseFile } from "./metrics/Metric";
 import nodeTypesConfig from "./config/nodeTypesConfig.json";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export class MetricCalculator {
     private readonly fileMetrics: Metric[] = [];
@@ -32,12 +35,8 @@ export class MetricCalculator {
     calculateMetrics(parseFiles: ParseFile[]) {
         const sourcesRoot = fs.realpathSync(this.config.sourcesPath);
 
-        console.log(
-            "\n\n",
-            "----- Calculating metrics for " + sourcesRoot + " recursively -----",
-            "\n\n"
-        );
-        console.log(" --- " + parseFiles.length + " files detected", "\n\n");
+        dlog("\n\n", "----- Calculating metrics for " + sourcesRoot + " recursively -----", "\n\n");
+        dlog(" --- " + parseFiles.length + " files detected", "\n\n");
 
         const fileMetrics = new Map<string, Map<string, MetricResult>>();
 
@@ -45,7 +44,7 @@ export class MetricCalculator {
             const metricResults = new Map<string, MetricResult>();
             fileMetrics.set(parseFile.filePath, metricResults);
 
-            console.log(" ------------ Parsing File " + parseFile.filePath + ":  ------------ ");
+            dlog(" ------------ Parsing File " + parseFile.filePath + ":  ------------ ");
 
             for (const metric of this.fileMetrics) {
                 const metricResult = metric.calculate(parseFile);

--- a/src/parser/metrics/Classes.ts
+++ b/src/parser/metrics/Classes.ts
@@ -4,9 +4,11 @@ import { TreeParser } from "../helper/TreeParser";
 import { ExpressionMetricMapping, QueryStatementInterface } from "../helper/Model";
 import { getQueryStatements } from "../helper/Helper";
 import { Metric, MetricResult, ParseFile } from "./Metric";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export class Classes implements Metric {
     private readonly statementsSuperSet: QueryStatementInterface[] = [];

--- a/src/parser/metrics/Classes.ts
+++ b/src/parser/metrics/Classes.ts
@@ -4,6 +4,9 @@ import { TreeParser } from "../helper/TreeParser";
 import { ExpressionMetricMapping, QueryStatementInterface } from "../helper/Model";
 import { getQueryStatements } from "../helper/Helper";
 import { Metric, MetricResult, ParseFile } from "./Metric";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export class Classes implements Metric {
     private readonly statementsSuperSet: QueryStatementInterface[] = [];
@@ -25,7 +28,7 @@ export class Classes implements Metric {
         const query = queryBuilder.build();
         const matches = query.matches(tree.rootNode);
 
-        console.log(this.getName() + " - " + matches.length);
+        dlog(this.getName() + " - " + matches.length);
 
         return {
             metricName: this.getName(),

--- a/src/parser/metrics/CommentLines.ts
+++ b/src/parser/metrics/CommentLines.ts
@@ -5,6 +5,9 @@ import { ExpressionMetricMapping, QueryStatementInterface } from "../helper/Mode
 import { getExpressionsByCategory, getQueryStatements } from "../helper/Helper";
 import { Metric, MetricResult, ParseFile } from "./Metric";
 import { SyntaxNode } from "tree-sitter";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export class CommentLines implements Metric {
     private readonly statementsSuperSet: QueryStatementInterface[] = [];
@@ -48,7 +51,7 @@ export class CommentLines implements Metric {
             return accumulator + commentLinesWithText - docBlockLines;
         }, 0);
 
-        console.log(this.getName() + " - " + commentLines);
+        dlog(this.getName() + " - " + commentLines);
 
         return {
             metricName: this.getName(),

--- a/src/parser/metrics/CommentLines.ts
+++ b/src/parser/metrics/CommentLines.ts
@@ -5,9 +5,11 @@ import { ExpressionMetricMapping, QueryStatementInterface } from "../helper/Mode
 import { getExpressionsByCategory, getQueryStatements } from "../helper/Helper";
 import { Metric, MetricResult, ParseFile } from "./Metric";
 import { SyntaxNode } from "tree-sitter";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export class CommentLines implements Metric {
     private readonly statementsSuperSet: QueryStatementInterface[] = [];

--- a/src/parser/metrics/Functions.ts
+++ b/src/parser/metrics/Functions.ts
@@ -4,9 +4,11 @@ import { TreeParser } from "../helper/TreeParser";
 import { ExpressionMetricMapping, QueryStatementInterface } from "../helper/Model";
 import { getQueryStatements } from "../helper/Helper";
 import { Metric, MetricResult, ParseFile } from "./Metric";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export class Functions implements Metric {
     private readonly statementsSuperSet: QueryStatementInterface[] = [];

--- a/src/parser/metrics/Functions.ts
+++ b/src/parser/metrics/Functions.ts
@@ -4,6 +4,9 @@ import { TreeParser } from "../helper/TreeParser";
 import { ExpressionMetricMapping, QueryStatementInterface } from "../helper/Model";
 import { getQueryStatements } from "../helper/Helper";
 import { Metric, MetricResult, ParseFile } from "./Metric";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export class Functions implements Metric {
     private readonly statementsSuperSet: QueryStatementInterface[] = [];
@@ -25,7 +28,7 @@ export class Functions implements Metric {
         const query = queryBuilder.build();
         const matches = query.matches(tree.rootNode);
 
-        console.log(this.getName() + " - " + matches.length);
+        dlog(this.getName() + " - " + matches.length);
 
         return {
             metricName: this.getName(),

--- a/src/parser/metrics/LinesOfCode.ts
+++ b/src/parser/metrics/LinesOfCode.ts
@@ -4,6 +4,9 @@ import { TreeParser } from "../helper/TreeParser";
 import { ExpressionMetricMapping, QueryStatementInterface } from "../helper/Model";
 import { formatCaptures, getQueryStatements } from "../helper/Helper";
 import { Metric, MetricResult, ParseFile } from "./Metric";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export class LinesOfCode implements Metric {
     private readonly statementsSuperSet: QueryStatementInterface[] = [];
@@ -26,6 +29,7 @@ export class LinesOfCode implements Metric {
         const matches = query.matches(tree.rootNode);
         const startRuleCaptures = query.captures(tree.rootNode);
         if (!matches.length) {
+            dlog("No match! " + this.getName() + " is assumed as 0");
             return {
                 metricName: this.getName(),
                 metricValue: 0,
@@ -39,7 +43,7 @@ export class LinesOfCode implements Metric {
         // Last line is an empty one, so add one line
         loc += startRuleTextCaptures[0].text.endsWith("\n") ? 1 : 0;
 
-        console.log(this.getName() + " - " + loc);
+        dlog(this.getName() + " - " + loc);
 
         return {
             metricName: this.getName(),

--- a/src/parser/metrics/LinesOfCode.ts
+++ b/src/parser/metrics/LinesOfCode.ts
@@ -4,9 +4,11 @@ import { TreeParser } from "../helper/TreeParser";
 import { ExpressionMetricMapping, QueryStatementInterface } from "../helper/Model";
 import { formatCaptures, getQueryStatements } from "../helper/Helper";
 import { Metric, MetricResult, ParseFile } from "./Metric";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export class LinesOfCode implements Metric {
     private readonly statementsSuperSet: QueryStatementInterface[] = [];

--- a/src/parser/metrics/McCabeComplexity.ts
+++ b/src/parser/metrics/McCabeComplexity.ts
@@ -8,9 +8,11 @@ import {
     QueryStatementInterface,
 } from "../helper/Model";
 import { Metric, MetricResult, ParseFile } from "./Metric";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export class McCabeComplexity implements Metric {
     private mccStatementsSuperSet: QueryStatementInterface[] = [];

--- a/src/parser/metrics/McCabeComplexity.ts
+++ b/src/parser/metrics/McCabeComplexity.ts
@@ -8,6 +8,9 @@ import {
     QueryStatementInterface,
 } from "../helper/Model";
 import { Metric, MetricResult, ParseFile } from "./Metric";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export class McCabeComplexity implements Metric {
     private mccStatementsSuperSet: QueryStatementInterface[] = [];
@@ -46,7 +49,7 @@ export class McCabeComplexity implements Metric {
         const query = queryBuilder.build();
         const matches = query.matches(tree.rootNode);
 
-        console.log(this.getName() + " - " + matches.length);
+        dlog(this.getName() + " - " + matches.length);
 
         return {
             metricName: this.getName(),

--- a/src/parser/metrics/Metric.ts
+++ b/src/parser/metrics/Metric.ts
@@ -35,7 +35,17 @@ export interface CouplingMetric {
     getName(): string;
 }
 
+/**
+ * Represents a file to be parsed, including its path and programming language.
+ */
 export interface ParseFile {
+    /**
+     * Programming language of the file.
+     */
     language: string;
+
+    /**
+     * Path to the file.
+     */
     filePath: string;
 }

--- a/src/parser/metrics/RealLinesOfCode.ts
+++ b/src/parser/metrics/RealLinesOfCode.ts
@@ -8,6 +8,9 @@ import {
 } from "../helper/Model";
 import { Metric, MetricResult, ParseFile } from "./Metric";
 import { formatCaptures } from "../helper/Helper";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export class RealLinesOfCode implements Metric {
     private startRuleStatementsSuperSet: QueryStatementInterface[] = [];
@@ -47,6 +50,7 @@ export class RealLinesOfCode implements Metric {
         const query = queryBuilder.build();
         const startRuleMatches = query.matches(tree.rootNode);
         if (!startRuleMatches.length) {
+            dlog("No match! " + this.getName() + " is assumed as 0");
             return {
                 metricName: this.getName(),
                 metricValue: 0,
@@ -75,7 +79,7 @@ export class RealLinesOfCode implements Metric {
         }, 0);
 
         const realLinesOfCode = Math.max(0, loc - commentLines - emptyLines);
-        console.log(this.getName() + " - " + realLinesOfCode);
+        dlog(this.getName() + " - " + realLinesOfCode);
 
         return {
             metricName: this.getName(),

--- a/src/parser/metrics/RealLinesOfCode.ts
+++ b/src/parser/metrics/RealLinesOfCode.ts
@@ -8,9 +8,11 @@ import {
 } from "../helper/Model";
 import { Metric, MetricResult, ParseFile } from "./Metric";
 import { formatCaptures } from "../helper/Helper";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export class RealLinesOfCode implements Metric {
     private startRuleStatementsSuperSet: QueryStatementInterface[] = [];

--- a/src/parser/metrics/coupling/CallExpressionResolver.ts
+++ b/src/parser/metrics/coupling/CallExpressionResolver.ts
@@ -2,9 +2,11 @@ import { Relationship } from "../Metric";
 import { Accessor } from "../../resolver/callExpressions/AbstractCollector";
 import { UnresolvedCallExpression } from "../../resolver/typeUsages/AbstractCollector";
 import { FullyQTN } from "../../resolver/fullyQualifiedTypeNames/AbstractCollector";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export function getAdditionalRelationships(
     tree: Map<string, Relationship[]>,
@@ -76,7 +78,7 @@ export function getAdditionalRelationships(
                             namespace.namespaceDelimiter +
                             namespace.className;
 
-                        dlog("\n\n" + accessor + " -- " + fullyQualifiedNameCandidate);
+                        dlog("\n\n", accessor, " -- ", fullyQualifiedNameCandidate);
 
                         // FirstAccessor is a property or method
                         // The type of myVariable must be an already added dependency of the current base type/class (filePath),
@@ -144,17 +146,17 @@ function resolveAccessorReturnType(
 ) {
     // TODO resolve return type (generics, etc.)
     dlog(
-        "Lookup Status: " +
-            !!matchingDependency +
-            " -> check return type add: " +
-            accessor.returnType +
-            matchingDependency +
-            "\n\n"
+        "Lookup Status: ",
+        !!matchingDependency,
+        " -> check return type add: ",
+        accessor.returnType,
+        matchingDependency,
+        "\n\n"
     );
 
     const accessorFileDependencies = tree.get(namespace.source) ?? [];
-    dlog("namespace.source " + namespace.source);
-    dlog("accessorFileDependencies " + accessorFileDependencies);
+    dlog("namespace.source", namespace.source);
+    dlog("accessorFileDependencies", accessorFileDependencies);
     for (const accessorFileDependency of accessorFileDependencies) {
         // TODO Imagine that returnType is MyTypeNumberOne
         //  and toClassName MyType
@@ -168,12 +170,12 @@ function resolveAccessorReturnType(
 
             if (alreadyAddedRelationships.has(uniqueId)) {
                 dlog(
-                    "SKIP ADDING RETURN TYPE: " +
-                        accessor.returnType +
-                        "already added: " +
-                        accessorFileDependency +
-                        alreadyAddedRelationships.has(uniqueId) +
-                        "\n\n"
+                    "SKIP ADDING RETURN TYPE: ",
+                    accessor.returnType,
+                    "already added: ",
+                    accessorFileDependency,
+                    alreadyAddedRelationships.has(uniqueId),
+                    "\n\n"
                 );
                 continue;
             }
@@ -191,7 +193,7 @@ function resolveAccessorReturnType(
                     usageType: "usage",
                 };
 
-                dlog("ADD RETURN TYPE: " + accessor.returnType + dependencyClone + "\n\n");
+                dlog("ADD RETURN TYPE: ", accessor.returnType, dependencyClone, "\n\n");
                 return additionalRelationships.push(dependencyClone);
             }
 

--- a/src/parser/metrics/coupling/CallExpressionResolver.ts
+++ b/src/parser/metrics/coupling/CallExpressionResolver.ts
@@ -2,6 +2,9 @@ import { Relationship } from "../Metric";
 import { Accessor } from "../../resolver/callExpressions/AbstractCollector";
 import { UnresolvedCallExpression } from "../../resolver/typeUsages/AbstractCollector";
 import { FullyQTN } from "../../resolver/fullyQualifiedTypeNames/AbstractCollector";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export function getAdditionalRelationships(
     tree: Map<string, Relationship[]>,
@@ -17,7 +20,7 @@ export function getAdditionalRelationships(
             continue;
         }
 
-        console.log("RESOLVING:", fileDependencies);
+        dlog("RESOLVING:", fileDependencies);
 
         const processedPublicAccessors = new Set<string>();
 
@@ -46,14 +49,14 @@ export function getAdditionalRelationships(
                 }
 
                 const clonedAccessors = [...publicAccessorsOfPrefix];
-                console.log(
+                dlog(
                     "CLONED_ACCESSORS",
                     namePart,
                     filePath,
                     clonedAccessors.length,
                     fileDependencies
                 );
-                console.log(clonedAccessors);
+                dlog(clonedAccessors.toString());
 
                 let added;
 
@@ -73,7 +76,7 @@ export function getAdditionalRelationships(
                             namespace.namespaceDelimiter +
                             namespace.className;
 
-                        console.log("\n\n", accessor, " -- ", fullyQualifiedNameCandidate);
+                        dlog("\n\n" + accessor + " -- " + fullyQualifiedNameCandidate);
 
                         // FirstAccessor is a property or method
                         // The type of myVariable must be an already added dependency of the current base type/class (filePath),
@@ -140,18 +143,18 @@ function resolveAccessorReturnType(
     alreadyAddedRelationships: Set<string>
 ) {
     // TODO resolve return type (generics, etc.)
-    console.log(
-        "Lookup Status: ",
-        !!matchingDependency,
-        " -> check return type add: ",
-        accessor.returnType,
-        matchingDependency,
-        "\n\n"
+    dlog(
+        "Lookup Status: " +
+            !!matchingDependency +
+            " -> check return type add: " +
+            accessor.returnType +
+            matchingDependency +
+            "\n\n"
     );
 
     const accessorFileDependencies = tree.get(namespace.source) ?? [];
-    console.log("namespace.source", namespace.source);
-    console.log("accessorFileDependencies", accessorFileDependencies);
+    dlog("namespace.source " + namespace.source);
+    dlog("accessorFileDependencies " + accessorFileDependencies);
     for (const accessorFileDependency of accessorFileDependencies) {
         // TODO Imagine that returnType is MyTypeNumberOne
         //  and toClassName MyType
@@ -164,13 +167,13 @@ function resolveAccessorReturnType(
             const uniqueId = accessorFileDependency.toNamespace + matchingDependency.fromNamespace;
 
             if (alreadyAddedRelationships.has(uniqueId)) {
-                console.log(
-                    "SKIP ADDING RETURN TYPE: ",
-                    accessor.returnType,
-                    "already added: ",
-                    accessorFileDependency,
-                    alreadyAddedRelationships.has(uniqueId),
-                    "\n\n"
+                dlog(
+                    "SKIP ADDING RETURN TYPE: " +
+                        accessor.returnType +
+                        "already added: " +
+                        accessorFileDependency +
+                        alreadyAddedRelationships.has(uniqueId) +
+                        "\n\n"
                 );
                 continue;
             }
@@ -188,7 +191,7 @@ function resolveAccessorReturnType(
                     usageType: "usage",
                 };
 
-                console.log("ADD RETURN TYPE: ", accessor.returnType, dependencyClone, "\n\n");
+                dlog("ADD RETURN TYPE: " + accessor.returnType + dependencyClone + "\n\n");
                 return additionalRelationships.push(dependencyClone);
             }
 

--- a/src/parser/metrics/coupling/Coupling.ts
+++ b/src/parser/metrics/coupling/Coupling.ts
@@ -11,6 +11,9 @@ import { getParseFile } from "../../helper/Helper";
 import { PublicAccessorCollector } from "../../resolver/PublicAccessorCollector";
 import { Accessor } from "../../resolver/callExpressions/AbstractCollector";
 import { getAdditionalRelationships } from "./CallExpressionResolver";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export class Coupling implements CouplingMetric {
     private namespaceCollector: NamespaceCollector;
@@ -67,14 +70,14 @@ export class Coupling implements CouplingMetric {
 
         // postprocessing
 
-        console.log("\n\n");
-        console.log("namespaces", namespaces, "\n\n");
-        console.log("usages", usagesCandidates);
-        console.log("\n\n", "unresolved call expressions", unresolvedCallExpressions, "\n\n");
-        console.log("\n\n", "publicAccessors", publicAccessors, "\n\n");
+        dlog("\n\n");
+        dlog("namespaces" + namespaces + "\n\n");
+        dlog("usages" + usagesCandidates);
+        dlog("\n\n" + "unresolved call expressions" + unresolvedCallExpressions + "\n\n");
+        dlog("\n\n" + "publicAccessors" + publicAccessors + "\n\n");
 
         let relationships = this.getRelationships(namespaces, usagesCandidates);
-        console.log("\n\n", relationships);
+        dlog("\n\n" + relationships);
 
         let couplingMetrics = this.calculateCouplingMetrics(relationships);
         const { tree, rootFiles } = this.buildDependencyTree(relationships, couplingMetrics);
@@ -86,7 +89,7 @@ export class Coupling implements CouplingMetric {
             this.alreadyAddedRelationships
         );
         relationships = relationships.concat(additionalRelationships);
-        console.log("\n\n", "additionalRelationships", additionalRelationships, "\n\n");
+        dlog("\n\n" + "additionalRelationships" + additionalRelationships + "\n\n");
 
         couplingMetrics = this.calculateCouplingMetrics(relationships);
 
@@ -189,7 +192,7 @@ export class Coupling implements CouplingMetric {
             );
         }
 
-        console.log("\n\n", couplingValues);
+        dlog("\n\n" + couplingValues);
         return couplingValues;
     }
 

--- a/src/parser/metrics/coupling/Coupling.ts
+++ b/src/parser/metrics/coupling/Coupling.ts
@@ -11,9 +11,11 @@ import { getParseFile } from "../../helper/Helper";
 import { PublicAccessorCollector } from "../../resolver/PublicAccessorCollector";
 import { Accessor } from "../../resolver/callExpressions/AbstractCollector";
 import { getAdditionalRelationships } from "./CallExpressionResolver";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export class Coupling implements CouplingMetric {
     private namespaceCollector: NamespaceCollector;
@@ -71,13 +73,13 @@ export class Coupling implements CouplingMetric {
         // postprocessing
 
         dlog("\n\n");
-        dlog("namespaces" + namespaces + "\n\n");
-        dlog("usages" + usagesCandidates);
-        dlog("\n\n" + "unresolved call expressions" + unresolvedCallExpressions + "\n\n");
-        dlog("\n\n" + "publicAccessors" + publicAccessors + "\n\n");
+        dlog("namespaces", namespaces, "\n\n");
+        dlog("usages", usagesCandidates);
+        dlog("\n\n", "unresolved call expressions", unresolvedCallExpressions, "\n\n");
+        dlog("\n\n", "publicAccessors", publicAccessors, "\n\n");
 
         let relationships = this.getRelationships(namespaces, usagesCandidates);
-        dlog("\n\n" + relationships);
+        dlog("\n\n", relationships);
 
         let couplingMetrics = this.calculateCouplingMetrics(relationships);
         const { tree, rootFiles } = this.buildDependencyTree(relationships, couplingMetrics);
@@ -89,7 +91,7 @@ export class Coupling implements CouplingMetric {
             this.alreadyAddedRelationships
         );
         relationships = relationships.concat(additionalRelationships);
-        dlog("\n\n" + "additionalRelationships" + additionalRelationships + "\n\n");
+        dlog("\n\n", "additionalRelationships", additionalRelationships, "\n\n");
 
         couplingMetrics = this.calculateCouplingMetrics(relationships);
 
@@ -192,7 +194,7 @@ export class Coupling implements CouplingMetric {
             );
         }
 
-        dlog("\n\n" + couplingValues);
+        dlog("\n\n", couplingValues);
         return couplingValues;
     }
 

--- a/src/parser/queries/QueryBuilder.ts
+++ b/src/parser/queries/QueryBuilder.ts
@@ -1,5 +1,8 @@
 import Parser, { Query } from "tree-sitter";
 import { QueryStatementInterface } from "../helper/Model";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export class QueryBuilder {
     private readonly treeSitterLanguage: any;
@@ -28,9 +31,9 @@ export class QueryBuilder {
             queryString = this.getBruteForcedStatementsQuery();
         }
 
-        // console.log("------------- Start Query: --------------")
-        // console.log(queryString);
-        // console.log("-----------------------------------------")
+        dlog("------------- Start Query: --------------");
+        dlog(queryString);
+        dlog("-----------------------------------------");
 
         return new Query(this.treeSitterLanguage, queryString);
     }

--- a/src/parser/queries/QueryBuilder.ts
+++ b/src/parser/queries/QueryBuilder.ts
@@ -1,8 +1,10 @@
 import Parser, { Query } from "tree-sitter";
 import { QueryStatementInterface } from "../helper/Model";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export class QueryBuilder {
     private readonly treeSitterLanguage: any;

--- a/src/parser/resolver/callExpressions/AbstractCollector.ts
+++ b/src/parser/resolver/callExpressions/AbstractCollector.ts
@@ -5,6 +5,9 @@ import { grammars } from "../../helper/Grammars";
 import { TreeParser } from "../../helper/TreeParser";
 import { FullyQTN } from "../fullyQualifiedTypeNames/AbstractCollector";
 import { SimpleQueryStatement } from "../../helper/Model";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export interface Accessor {
     name: string;
@@ -40,7 +43,7 @@ export abstract class AbstractCollector {
                 source?: string;
             }[] = formatCaptures(tree, publicAccessorsCaptures);
 
-            console.log("public accessors captures", accessorsTextCaptures);
+            dlog("public accessors captures" + accessorsTextCaptures.toString());
 
             // first index must be the return type
             // second index must be the accessor name

--- a/src/parser/resolver/callExpressions/AbstractCollector.ts
+++ b/src/parser/resolver/callExpressions/AbstractCollector.ts
@@ -45,7 +45,7 @@ export abstract class AbstractCollector {
                 source?: string;
             }[] = formatCaptures(tree, publicAccessorsCaptures);
 
-            dlog("public accessors captures" + accessorsTextCaptures.toString());
+            dlog("public accessors captures", accessorsTextCaptures);
 
             // first index must be the return type
             // second index must be the accessor name

--- a/src/parser/resolver/callExpressions/AbstractCollector.ts
+++ b/src/parser/resolver/callExpressions/AbstractCollector.ts
@@ -5,9 +5,11 @@ import { grammars } from "../../helper/Grammars";
 import { TreeParser } from "../../helper/TreeParser";
 import { FullyQTN } from "../fullyQualifiedTypeNames/AbstractCollector";
 import { SimpleQueryStatement } from "../../helper/Model";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export interface Accessor {
     name: string;

--- a/src/parser/resolver/fullyQualifiedTypeNames/resolverStrategy/QueryStrategy.ts
+++ b/src/parser/resolver/fullyQualifiedTypeNames/resolverStrategy/QueryStrategy.ts
@@ -5,6 +5,9 @@ import { grammars } from "../../../helper/Grammars";
 import { formatCaptures } from "../../../helper/Helper";
 import { ParseFile } from "../../../metrics/Metric";
 import { SimpleQueryStatement } from "../../../helper/Model";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export class QueryStrategy {
     protected cache: Map<string, Map<string, FullyQTN>> = new Map();
@@ -30,7 +33,7 @@ export class QueryStrategy {
         const captures = query.captures(tree.rootNode);
         const textCaptures = formatCaptures(tree, captures);
 
-        console.log("namespace definitions", parseFile.filePath, textCaptures);
+        dlog("namespace definitions" + parseFile.filePath + textCaptures);
 
         for (let index = 0; index < textCaptures.length; index += 1) {
             const namespaceName = textCaptures[index].text;

--- a/src/parser/resolver/fullyQualifiedTypeNames/resolverStrategy/QueryStrategy.ts
+++ b/src/parser/resolver/fullyQualifiedTypeNames/resolverStrategy/QueryStrategy.ts
@@ -5,9 +5,11 @@ import { grammars } from "../../../helper/Grammars";
 import { formatCaptures } from "../../../helper/Helper";
 import { ParseFile } from "../../../metrics/Metric";
 import { SimpleQueryStatement } from "../../../helper/Model";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export class QueryStrategy {
     protected cache: Map<string, Map<string, FullyQTN>> = new Map();

--- a/src/parser/resolver/fullyQualifiedTypeNames/resolverStrategy/QueryStrategy.ts
+++ b/src/parser/resolver/fullyQualifiedTypeNames/resolverStrategy/QueryStrategy.ts
@@ -35,7 +35,7 @@ export class QueryStrategy {
         const captures = query.captures(tree.rootNode);
         const textCaptures = formatCaptures(tree, captures);
 
-        dlog("namespace definitions" + parseFile.filePath + textCaptures);
+        dlog("namespace definitions", parseFile.filePath, textCaptures);
 
         for (let index = 0; index < textCaptures.length; index += 1) {
             const namespaceName = textCaptures[index].text;

--- a/src/parser/resolver/typeUsages/AbstractCollector.ts
+++ b/src/parser/resolver/typeUsages/AbstractCollector.ts
@@ -5,9 +5,11 @@ import { TreeParser } from "../../helper/TreeParser";
 import { NamespaceCollector } from "../NamespaceCollector";
 import { ParseFile } from "../../metrics/Metric";
 import { SimpleQueryStatement } from "../../helper/Model";
-import { debuglog } from "node:util";
+import { debuglog, DebugLoggerFunction } from "node:util";
 
-const dlog = debuglog("metric-gardener");
+let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
+    dlog = logger;
+});
 
 export interface ImportReference {
     usedNamespace: string;

--- a/src/parser/resolver/typeUsages/AbstractCollector.ts
+++ b/src/parser/resolver/typeUsages/AbstractCollector.ts
@@ -5,6 +5,9 @@ import { TreeParser } from "../../helper/TreeParser";
 import { NamespaceCollector } from "../NamespaceCollector";
 import { ParseFile } from "../../metrics/Metric";
 import { SimpleQueryStatement } from "../../helper/Model";
+import { debuglog } from "node:util";
+
+const dlog = debuglog("metric-gardener");
 
 export interface ImportReference {
     usedNamespace: string;
@@ -60,15 +63,15 @@ export abstract class AbstractCollector {
 
         this.processedPublicAccessors = new Set();
 
-        console.log("Alias Map:", parseFile.filePath, this.importsBySuffixOrAlias);
-        console.log("Import References", parseFile.filePath, importReferences);
+        dlog("Alias Map:", parseFile.filePath, this.importsBySuffixOrAlias);
+        dlog("Import References", parseFile.filePath, importReferences);
 
         const { candidates, unresolvedCallExpressions } = this.getUsages(
             parseFile,
             namespaceCollector,
             importReferences
         );
-        console.log("UsagesAndCandidates", parseFile.filePath, candidates);
+        dlog("UsagesAndCandidates", parseFile.filePath, candidates);
 
         return {
             candidates,
@@ -93,7 +96,7 @@ export abstract class AbstractCollector {
         const importsCaptures = importsQuery.captures(tree.rootNode);
         const importsTextCaptures = formatCaptures(tree, importsCaptures);
 
-        console.log(importsTextCaptures);
+        dlog(importsTextCaptures);
 
         const importsOfFile: ImportReference[] = [];
 
@@ -160,7 +163,7 @@ export abstract class AbstractCollector {
         const importCaptures = groupedImportsQuery.captures(tree.rootNode);
         const importTextCaptures = formatCaptures(tree, importCaptures);
 
-        console.log(importTextCaptures);
+        dlog(importTextCaptures);
 
         const importsOfFile: ImportReference[] = [];
 
@@ -243,7 +246,7 @@ export abstract class AbstractCollector {
             resolved: boolean;
         }[] = formatCaptures(tree, usagesCaptures);
 
-        console.log("class/object usages", usagesTextCaptures);
+        dlog("class/object usages", usagesTextCaptures);
 
         const usagesAndCandidates: TypeUsageCandidate[] = [];
         const unresolvedCallExpressions: UnresolvedCallExpression[] = [];


### PR DESCRIPTION
Done as suggested by the issue #2. The debug outputs can be enabled by adding the environment variable `NODE_DEBUG` with the value `metric-gardener`.

When the debug-outputs are disabled, the performance of analyzing the jUnit 4 code base improves from around 10-11 seconds before this change to around 9-10 seconds. However, with debug-outputs enabled, the execution time seems to be a bit slower than before, at 11-12 seconds. This could be related to additional outputs, like the "METRIC-GARDENER" before each line introduced by using debuglog, or the re-enabled printing of the query statements.

Should probably not be merged before #17 is approved, as it builds upon it.