### PR TITLE
Replaced Regex for empty comment lines

### DIFF
--- a/src/parser/GenericParser.test.ts
+++ b/src/parser/GenericParser.test.ts
@@ -372,6 +372,30 @@ describe("GenericParser", () => {
         });
     });
 
+    describe("parses GO commentLines metric", () => {
+        it(
+            "should count number of comment lines correctly, including line with curly brackets, inline comments" +
+                " and text lines inside block comment",
+            () => {
+                const inputPath = fs.realpathSync(goTestResourcesPath + "if-statements.go");
+                const parser = new GenericParser(getParserConfiguration(inputPath));
+                const results = parser.calculateMetrics();
+
+                expect(results.fileMetrics.get(inputPath)?.get("comment_lines")?.metricValue).toBe(
+                    4
+                );
+            }
+        );
+
+        it("should count number of comment lines correctly, including multiple successive comments", () => {
+            const inputPath = fs.realpathSync(goTestResourcesPath + "go-example-code.go");
+            const parser = new GenericParser(getParserConfiguration(inputPath));
+            const results = parser.calculateMetrics();
+
+            expect(results.fileMetrics.get(inputPath)?.get("comment_lines")?.metricValue).toBe(7);
+        });
+    });
+
     describe("parses GO lines of code metric", () => {
         it("should count number of lines correctly for a non-empty file with empty last line", () => {
             const inputPath = fs.realpathSync(goTestResourcesPath + "empty-last-line.go");

--- a/src/parser/GenericParser.test.ts
+++ b/src/parser/GenericParser.test.ts
@@ -133,6 +133,22 @@ describe("GenericParser", () => {
         });
     });
 
+    describe("parses PHP commentLines metric", () => {
+        it(
+            "should count number of comment lines correctly, including line with curly brackets and text lines " +
+                "inside block comment",
+            () => {
+                const inputPath = fs.realpathSync(phpTestResourcesPath + "php-example-code.php");
+                const parser = new GenericParser(getParserConfiguration(inputPath));
+                const results = parser.calculateMetrics();
+
+                expect(results.fileMetrics.get(inputPath)?.get("comment_lines")?.metricValue).toBe(
+                    8
+                );
+            }
+        );
+    });
+
     describe("parses TypeScript McCabeComplexity metric", () => {
         it("should count if statements correctly", () => {
             const inputPath = fs.realpathSync(tsTestResourcesPath + "if-statements.ts");
@@ -214,7 +230,7 @@ describe("GenericParser", () => {
     });
 
     describe("parses TypeScript commentLines metric", () => {
-        it("should count properly and ignore file header, class description and doc block comment lines", () => {
+        it("should count properly and ignore file header, class description and doc block tag comment lines", () => {
             const inputPath = fs.realpathSync(tsTestResourcesPath + "comments.ts");
             const parser = new GenericParser(getParserConfiguration(inputPath));
             const results = parser.calculateMetrics();

--- a/src/parser/metrics/CommentLines.ts
+++ b/src/parser/metrics/CommentLines.ts
@@ -102,7 +102,7 @@ export class CommentLines implements Metric {
      * @private
      */
     private countDocBlockTagLines(text: string) {
-        return text.split(/\r\n|\r|\n/g).filter((entry) => /^[ *]*@[a-z]+/g.test(entry));
+        return text.split(/\r\n|\r|\n/g).filter((entry) => /^[\s*]*@[a-z]+/g.test(entry));
     }
 
     /**

--- a/src/parser/metrics/CommentLines.ts
+++ b/src/parser/metrics/CommentLines.ts
@@ -11,11 +11,20 @@ let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
     dlog = logger;
 });
 
+/**
+ * Calculates the number of comment lines.
+ * Does not count for empty comment lines, lines with JavaDoc-like documentation block tags (e.g. @param)
+ * and file header comments.
+ */
 export class CommentLines implements Metric {
     private readonly statementsSuperSet: QueryStatementInterface[] = [];
     private readonly commentExpressions: string[] = [];
     private excludedFileHeaderComments: SyntaxNode[] = [];
 
+    /**
+     * Constructor of the class {@link CommentLines}.
+     * @param allNodeTypes List of all configured syntax node types.
+     */
     constructor(allNodeTypes: ExpressionMetricMapping[]) {
         this.statementsSuperSet = getQueryStatements(allNodeTypes, this.getName());
         this.commentExpressions = getExpressionsByCategory(allNodeTypes, this.getName(), "comment");
@@ -40,15 +49,12 @@ export class CommentLines implements Metric {
         const commentLines = matches.reduce((accumulator, match) => {
             const captureNode = match.captures[0].node;
 
-            if (
-                this.isFileHeaderComment(captureNode) ||
-                this.isCommentFollowedByClass(captureNode)
-            ) {
+            if (this.isFileHeaderComment(captureNode) || this.isNodeFollowedByClass(captureNode)) {
                 return accumulator;
             }
 
-            const commentLinesWithText = this.findTextLines(captureNode.text).length;
-            const docBlockLines = this.findDocBlockLines(captureNode.text).length;
+            const commentLinesWithText = this.countTextLines(captureNode.text).length;
+            const docBlockLines = this.countDocBlockTagLines(captureNode.text).length;
 
             return accumulator + commentLinesWithText - docBlockLines;
         }, 0);
@@ -61,19 +67,50 @@ export class CommentLines implements Metric {
         };
     }
 
-    private isCommentFollowedByClass(node: SyntaxNode) {
+    /**
+     * Checks whether there is a class definition following after the specified syntax node.
+     * @param node The syntax node to check.
+     * @return Whether there is a class definition following.
+     * @private
+     */
+    private isNodeFollowedByClass(node: SyntaxNode) {
         // this is not language independent
         return node.nextSibling?.type.includes("class");
     }
 
-    private findTextLines(text: string) {
-        return text.split(/\r\n|\r|\n/g).filter((entry) => /[a-zA-Z0-9]+/g.test(entry));
+    /**
+     * Counts the number of non-empty comment lines in the supplied string.
+     *
+     * Should exclude most empty comment lines following the inline comment line syntaxes listed in the
+     * {@link https://www.researchgate.net/publication/335541386_TAXONOMY_AND_DESIGN_CONSIDERATIONS_FOR_COMMENTS_IN_PROGRAMMING_LANGUAGES_A_QUALITY_PERSPECTIVE|linked paper},
+     * the C-style block comment syntax and the "%" syntax, used, e.g., by latex.
+     * However, if a non-empty comment line includes only symbols that are included in the comment syntax for one of
+     * the supported languages, these lines are incorrectly counted as empty.
+     *
+     * @param text The text for which non-empty comment lines should be counted.
+     * @return The number of non-empty comment lines.
+     * @private
+     */
+    private countTextLines(text: string) {
+        return text.split(/\r\n|\r|\n/g).filter((entry) => /[^\s/*#%';!-]/g.test(entry));
     }
 
-    private findDocBlockLines(text: string) {
+    /**
+     * Counts the number of lines that include JavaDoc-like documentation block tags (e.g. @param) in the supplied string.
+     * @param text The text for which the number of lines should be counted.
+     * @return The number of lines that include block tags.
+     * @private
+     */
+    private countDocBlockTagLines(text: string) {
         return text.split(/\r\n|\r|\n/g).filter((entry) => /^[ *]*@[a-z]+/g.test(entry));
     }
 
+    /**
+     * Checks whether the specified node represents an excluded file header comment.
+     * @param captureNode The node to check.
+     * @return Whether the node represents an excluded file header comment.
+     * @private
+     */
     private isFileHeaderComment(captureNode: SyntaxNode) {
         return this.excludedFileHeaderComments.some((excludedComment) => {
             return (
@@ -85,7 +122,13 @@ export class CommentLines implements Metric {
         });
     }
 
-    private getExcludedFileHeaderComments(rootNodeChildren): SyntaxNode[] {
+    /**
+     * Determines all syntax nodes that represent file header comments
+     * in order to exclude them from the number of comment lines.
+     * @param rootNodeChildren The children of the root note of the syntax tree.
+     * @private
+     */
+    private getExcludedFileHeaderComments(rootNodeChildren: SyntaxNode[]): SyntaxNode[] {
         const excludedComments: SyntaxNode[] = [];
         const clonedChildren = [...rootNodeChildren];
 

--- a/src/parser/metrics/RealLinesOfCode.ts
+++ b/src/parser/metrics/RealLinesOfCode.ts
@@ -82,7 +82,7 @@ export class RealLinesOfCode implements Metric {
      * @private
      */
     private countEmptyLines(text: string) {
-        return text.split(/\r\n|\r|\n/g).filter((entry) => /^[ \t]*$/.test(entry)).length;
+        return text.split(/\r\n|\r|\n/g).filter((entry) => /^\s*$/.test(entry)).length;
     }
 
     getName(): string {


### PR DESCRIPTION
Instead of counting every comment line as empty that does not contain any alphanumeric characters, this now looks for any characters that are not used to mark comment lines following the inline comment line syntaxes listed in [this paper](https://www.researchgate.net/publication/335541386_TAXONOMY_AND_DESIGN_CONSIDERATIONS_FOR_COMMENTS_IN_PROGRAMMING_LANGUAGES_A_QUALITY_PERSPECTIVE),
the C-style block comment syntax or the "%" syntax, used, e.g., by latex. 

However, if a non-empty comment line includes only symbols that are included in the comment syntax for one of the supported languages, these lines are still incorrectly counted as empty. I do not really see how to improve this, unless performing distinction of cases based on the programming language.

Further changes:

- Added code documentation and test cases for the comment_lines metric.