### PR TITLE
Bugfix for real lines of code with empty files

### DIFF
--- a/resources/typescript/single-comment.ts
+++ b/resources/typescript/single-comment.ts
@@ -1,0 +1,1 @@
+// A single comment

--- a/src/parser/GenericParser.test.ts
+++ b/src/parser/GenericParser.test.ts
@@ -388,6 +388,16 @@ describe("GenericParser", () => {
             );
         });
 
+        it("should count correctly for a file with a single comment", async () => {
+            const inputPath = fs.realpathSync(tsTestResourcesPath + "single-comment.ts");
+            const parser = new GenericParser(getParserConfiguration(inputPath));
+            const results = await parser.calculateMetrics();
+
+            expect(results.fileMetrics.get(inputPath)?.get("real_lines_of_code")?.metricValue).toBe(
+                0
+            );
+        });
+
         it("should count correctly if there is a comment in the same line as actual code", async () => {
             const inputPath = fs.realpathSync(tsTestResourcesPath + "same-line-comment.ts");
             const parser = new GenericParser(getParserConfiguration(inputPath));

--- a/src/parser/GenericParser.test.ts
+++ b/src/parser/GenericParser.test.ts
@@ -191,6 +191,16 @@ describe("GenericParser", () => {
             );
         });
 
+        it("should count correctly for an empty file", async () => {
+            const inputPath = fs.realpathSync(phpTestResourcesPath + "empty.php");
+            const parser = new GenericParser(getParserConfiguration(inputPath));
+            const results = await parser.calculateMetrics();
+
+            expect(results.fileMetrics.get(inputPath)?.get("real_lines_of_code")?.metricValue).toBe(
+                0
+            );
+        });
+
         it("should count correctly if there is a comment in the same line as actual code", async () => {
             const inputPath = fs.realpathSync(phpTestResourcesPath + "same-line-comment.php");
             const parser = new GenericParser(getParserConfiguration(inputPath));
@@ -368,6 +378,16 @@ describe("GenericParser", () => {
             );
         });
 
+        it("should count correctly for an empty file", async () => {
+            const inputPath = fs.realpathSync(tsTestResourcesPath + "empty.ts");
+            const parser = new GenericParser(getParserConfiguration(inputPath));
+            const results = await parser.calculateMetrics();
+
+            expect(results.fileMetrics.get(inputPath)?.get("real_lines_of_code")?.metricValue).toBe(
+                0
+            );
+        });
+
         it("should count correctly if there is a comment in the same line as actual code", async () => {
             const inputPath = fs.realpathSync(tsTestResourcesPath + "same-line-comment.ts");
             const parser = new GenericParser(getParserConfiguration(inputPath));
@@ -535,6 +555,16 @@ describe("GenericParser", () => {
             );
         });
 
+        it("should count correctly for an empty file", async () => {
+            const inputPath = fs.realpathSync(goTestResourcesPath + "empty.go");
+            const parser = new GenericParser(getParserConfiguration(inputPath));
+            const results = await parser.calculateMetrics();
+
+            expect(results.fileMetrics.get(inputPath)?.get("real_lines_of_code")?.metricValue).toBe(
+                0
+            );
+        });
+
         it("should count correctly if there is a comment that includes code", async () => {
             const inputPath = fs.realpathSync(goTestResourcesPath + "if-statements.go");
             const parser = new GenericParser(getParserConfiguration(inputPath));
@@ -574,6 +604,16 @@ describe("GenericParser", () => {
 
             expect(results.fileMetrics.get(inputPath)?.get("real_lines_of_code")?.metricValue).toBe(
                 9
+            );
+        });
+
+        it("should count correctly for an empty file", async () => {
+            const inputPath = fs.realpathSync(pythonTestResourcesPath + "empty.py");
+            const parser = new GenericParser(getParserConfiguration(inputPath));
+            const results = await parser.calculateMetrics();
+
+            expect(results.fileMetrics.get(inputPath)?.get("real_lines_of_code")?.metricValue).toBe(
+                0
             );
         });
 

--- a/src/parser/metrics/RealLinesOfCode.ts
+++ b/src/parser/metrics/RealLinesOfCode.ts
@@ -31,28 +31,28 @@ export class RealLinesOfCode implements Metric {
      * {@link https://tree-sitter.github.io/tree-sitter/using-parsers#walking-trees-with-tree-cursors|Tree-sitter documentation},
      * this is the most efficient way to traverse a syntax tree.
      * @param cursor A {@link TreeCursor} for the syntax tree.
-     * @param sureCodeLines A set in which the line numbers of the found code lines are stored.
+     * @param realCodeLines A set in which the line numbers of the found code lines are stored.
      */
-    walkTree(cursor: TreeCursor, sureCodeLines = new Set<number>()) {
+    walkTree(cursor: TreeCursor, realCodeLines = new Set<number>()) {
         // This is not a comment syntax node, so assume it includes "real code".
         if (!this.commentStatementsSet.has(cursor.currentNode.type)) {
             // Assume that first and last line of whatever kind of node this is, is a real code line.
             // This assumption should hold for all kinds of block/composed statements in (hopefully) all languages.
-            sureCodeLines.add(cursor.startPosition.row);
+            realCodeLines.add(cursor.startPosition.row);
             // Adding the last line is not necessary, as every last line has to have some syntactical element,
             // which is again expressed as another syntax node.
         }
         // Recurse, depth-first
         if (cursor.gotoFirstChild()) {
-            this.walkTree(cursor, sureCodeLines);
+            this.walkTree(cursor, realCodeLines);
         }
         if (cursor.gotoNextSibling()) {
-            this.walkTree(cursor, sureCodeLines);
+            this.walkTree(cursor, realCodeLines);
         } else {
             // Completed searching this part of the tree, so go up now.
             cursor.gotoParent();
         }
-        return sureCodeLines;
+        return realCodeLines;
     }
 
     async calculate(parseFile: ParseFile, tree: Parser.Tree): Promise<MetricResult> {
@@ -62,9 +62,9 @@ export class RealLinesOfCode implements Metric {
         // Assume the root node is always some kind of program/file/compilation_unit stuff.
         // So if there are no child nodes, the file is empty.
         if (cursor.gotoFirstChild()) {
-            const sureCodeLines = this.walkTree(cursor);
-            dlog("Included lines for rloc: ", sureCodeLines);
-            rloc = sureCodeLines.size;
+            const realCodeLines = this.walkTree(cursor);
+            dlog("Included lines for rloc: ", realCodeLines);
+            rloc = realCodeLines.size;
         }
 
         dlog(this.getName() + " - " + rloc);

--- a/src/parser/metrics/RealLinesOfCode.ts
+++ b/src/parser/metrics/RealLinesOfCode.ts
@@ -56,14 +56,16 @@ export class RealLinesOfCode implements Metric {
     }
 
     async calculate(parseFile: ParseFile, tree: Parser.Tree): Promise<MetricResult> {
+        let rloc = 0;
         const cursor = tree.walk();
-        // Assume the root node is always some kind of program/file/compilation_unit stuff
-        cursor.gotoFirstChild();
-        const sureCodeLines = this.walkTree(cursor);
 
-        dlog("Included lines for rloc: ", sureCodeLines);
-
-        const rloc = sureCodeLines.size;
+        // Assume the root node is always some kind of program/file/compilation_unit stuff.
+        // So if there are no child nodes, the file is empty.
+        if (cursor.gotoFirstChild()) {
+            const sureCodeLines = this.walkTree(cursor);
+            dlog("Included lines for rloc: ", sureCodeLines);
+            rloc = sureCodeLines.size;
+        }
 
         dlog(this.getName() + " - " + rloc);
 


### PR DESCRIPTION
Empty files have now a rloc-value of 0 instead of 1, as root nodes without child nodes are no longer counted.

Resolves #47