### PR TITLE
Special treatment for python block comments

### DIFF
--- a/src/parser/metrics/CommentLines.ts
+++ b/src/parser/metrics/CommentLines.ts
@@ -1,9 +1,14 @@
 import { QueryBuilder } from "../queries/QueryBuilder";
-import { ExpressionMetricMapping, QueryStatementInterface } from "../helper/Model";
+import {
+    ExpressionMetricMapping,
+    QueryStatementInterface,
+    SimpleQueryStatement,
+} from "../helper/Model";
 import { getQueryStatements } from "../helper/Helper";
 import { FileMetric, Metric, MetricResult, ParseFile } from "./Metric";
 import Parser, { QueryMatch, SyntaxNode } from "tree-sitter";
 import { debuglog, DebugLoggerFunction } from "node:util";
+import { Languages } from "../helper/Languages";
 
 let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
     dlog = logger;
@@ -25,6 +30,16 @@ export class CommentLines implements Metric {
     }
 
     async calculate(parseFile: ParseFile, tree: Parser.Tree): Promise<MetricResult> {
+        switch (parseFile.language) {
+            case Languages.Python:
+                this.statementsSuperSet.push(
+                    new SimpleQueryStatement(
+                        "(expression_statement (string)) @python_multiline_comment"
+                    )
+                );
+                break;
+        }
+
         const queryBuilder = new QueryBuilder(parseFile, tree);
         queryBuilder.setStatements(this.statementsSuperSet);
 

--- a/src/parser/metrics/RealLinesOfCode.ts
+++ b/src/parser/metrics/RealLinesOfCode.ts
@@ -69,13 +69,15 @@ export class RealLinesOfCode implements Metric {
     }
 
     async calculate(parseFile: ParseFile, tree: Parser.Tree): Promise<MetricResult> {
-        let isCommentFunction: (node: Parser.SyntaxNode) => boolean = (node: Parser.SyntaxNode) =>
-            this.commentStatementsSet.has(node.type);
+        let isCommentFunction: (node: Parser.SyntaxNode) => boolean;
 
         switch (parseFile.language) {
             case Languages.Python:
                 isCommentFunction = (node: Parser.SyntaxNode) => this.isPythonComment(node);
                 break;
+            default:
+                isCommentFunction = (node: Parser.SyntaxNode) =>
+                    this.commentStatementsSet.has(node.type);
         }
 
         let rloc = 0;

--- a/src/parser/metrics/RealLinesOfCode.ts
+++ b/src/parser/metrics/RealLinesOfCode.ts
@@ -72,7 +72,6 @@ export class RealLinesOfCode implements Metric {
         let isCommentFunction: (node: Parser.SyntaxNode) => boolean;
 
         if (parseFile.language == Languages.Python) {
-            // Special treatment for python multiline comments:
             isCommentFunction = (node: Parser.SyntaxNode) => this.isPythonComment(node);
         } else {
             isCommentFunction = (node: Parser.SyntaxNode) => this.isComment(node);
@@ -101,20 +100,17 @@ export class RealLinesOfCode implements Metric {
         return this.commentStatementsSet.has(node.type);
     }
 
-    /**
-     * Checks whether the node should count as a comment in python.
-     *
-     * Adds special handling for python multiline comments:
-     * Multiline comments in python are (multiline) strings that are
-     * neither assigned to a variable nor used as call parameter.
-     */
     isPythonComment(node: Parser.SyntaxNode) {
+        return this.isComment(node) || this.isPythonMultilineComment(node);
+    }
+
+    isPythonMultilineComment(node: Parser.SyntaxNode) {
+        // Multiline comments in python are (multiline) strings that are
+        // neither assigned to a variable nor used as call parameter.
         return (
-            this.isComment(node) ||
-            // Special handling for multiline comments:
-            (node.type === "expression_statement" &&
-                node.childCount === 1 &&
-                node.child(0)?.type === "string")
+            node.type === "expression_statement" &&
+            node.childCount === 1 &&
+            node.child(0)?.type === "string"
         );
     }
 

--- a/src/parser/metrics/RealLinesOfCode.ts
+++ b/src/parser/metrics/RealLinesOfCode.ts
@@ -3,6 +3,7 @@ import { FileMetric, Metric, MetricResult, ParseFile } from "./Metric";
 import Parser, { TreeCursor } from "tree-sitter";
 import { getExpressionsByCategory } from "../helper/Helper";
 import { debuglog, DebugLoggerFunction } from "node:util";
+import { Languages } from "../helper/Languages";
 
 let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
     dlog = logger;
@@ -32,10 +33,15 @@ export class RealLinesOfCode implements Metric {
      * this is the most efficient way to traverse a syntax tree.
      * @param cursor A {@link TreeCursor} for the syntax tree.
      * @param realLinesOfCode A set in which the line numbers of the found code lines are stored.
+     * @param isComment Function that checks whether a node is a comment or not.
      */
-    walkTree(cursor: TreeCursor, realLinesOfCode = new Set<number>()) {
+    walkTree(
+        cursor: TreeCursor,
+        isComment: (node: Parser.SyntaxNode) => boolean,
+        realLinesOfCode = new Set<number>()
+    ) {
         // This is not a comment syntax node, so assume it includes "real code".
-        if (!this.commentStatementsSet.has(cursor.currentNode.type)) {
+        if (!isComment(cursor.currentNode)) {
             // Assume that first and last line of whatever kind of node this is, is a real code line.
             // This assumption should hold for all kinds of block/composed statements in (hopefully) all languages.
             realLinesOfCode.add(cursor.startPosition.row);
@@ -47,13 +53,14 @@ export class RealLinesOfCode implements Metric {
                     realLinesOfCode.add(i);
                 }
             }
-        }
-        // Recurse, depth-first
-        if (cursor.gotoFirstChild()) {
-            this.walkTree(cursor, realLinesOfCode);
+
+            // Recurse, depth-first
+            if (cursor.gotoFirstChild()) {
+                this.walkTree(cursor, isComment, realLinesOfCode);
+            }
         }
         if (cursor.gotoNextSibling()) {
-            this.walkTree(cursor, realLinesOfCode);
+            this.walkTree(cursor, isComment, realLinesOfCode);
         } else {
             // Completed searching this part of the tree, so go up now.
             cursor.gotoParent();
@@ -62,13 +69,22 @@ export class RealLinesOfCode implements Metric {
     }
 
     async calculate(parseFile: ParseFile, tree: Parser.Tree): Promise<MetricResult> {
+        let isCommentFunction: (node: Parser.SyntaxNode) => boolean = (node: Parser.SyntaxNode) =>
+            this.commentStatementsSet.has(node.type);
+
+        switch (parseFile.language) {
+            case Languages.Python:
+                isCommentFunction = (node: Parser.SyntaxNode) => this.isPythonComment(node);
+                break;
+        }
+
         let rloc = 0;
         const cursor = tree.walk();
 
         // Assume the root node is always some kind of program/file/compilation_unit stuff.
         // So if there are no child nodes, the file is empty.
         if (cursor.gotoFirstChild()) {
-            const realLinesOfCode = this.walkTree(cursor);
+            const realLinesOfCode = this.walkTree(cursor, isCommentFunction);
             dlog("Included lines for rloc: ", realLinesOfCode);
             rloc = realLinesOfCode.size;
         }
@@ -79,6 +95,20 @@ export class RealLinesOfCode implements Metric {
             metricName: this.getName(),
             metricValue: rloc,
         };
+    }
+
+    /**
+     * Checks whether the node should count as a comment in python. Special handling for python multiline comments.
+     * @param node The node to check.
+     * @return Whether the node is a comment.
+     */
+    isPythonComment(node: Parser.SyntaxNode) {
+        return (
+            this.commentStatementsSet.has(node.type) ||
+            (node.type === "expression_statement" &&
+                node.childCount === 1 &&
+                node.child(0)?.type === "string")
+        );
     }
 
     getName(): string {

--- a/test/parser/PythonMetrics.test.ts
+++ b/test/parser/PythonMetrics.test.ts
@@ -15,8 +15,12 @@ describe("Python metrics test", () => {
     });
 
     describe("parses Python comment lines metric", () => {
-        it.skip("should count correctly, excluding inline and block comments", async () => {
-            await testFileMetrics(pythonTestResourcesPath + "loops.py", FileMetric.commentLines, 5);
+        it("should count correctly, excluding inline and block comments", async () => {
+            await testFileMetrics(
+                pythonTestResourcesPath + "block-comment.py",
+                FileMetric.commentLines,
+                7
+            );
         });
     });
 
@@ -45,7 +49,7 @@ describe("Python metrics test", () => {
             );
         });
 
-        it.skip("should count correctly in the presence of block comments", async () => {
+        it("should count correctly in the presence of block comments", async () => {
             await testFileMetrics(
                 pythonTestResourcesPath + "block-comment.py",
                 FileMetric.realLinesOfCode,


### PR DESCRIPTION
Adds special handling for python multiline comments, which are multiline strings that are neither stored in a variable/constant nor passed to a function.

Closes #31