### PR TITLE
Tech: Removed unused javascript linear programming solver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "0.1.1",
             "dependencies": {
                 "copyfiles": "^2.4.1",
-                "javascript-lp-solver": "^0.4.24",
                 "tree-sitter": "^0.20.6",
                 "tree-sitter-c-sharp": "^0.20.0",
                 "tree-sitter-cpp": "^0.20.3",
@@ -5391,11 +5390,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/javascript-lp-solver": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/javascript-lp-solver/-/javascript-lp-solver-0.4.24.tgz",
-            "integrity": "sha512-5edoDKnMrt/u3M6GnZKDDIPxOyFOg+WrwDv8mjNiMC2DePhy2H9/FFQgf4ggywaXT1utvkxusJcjQUER72cZmA=="
         },
         "node_modules/jest": {
             "version": "27.3.1",
@@ -13747,11 +13741,6 @@
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
             }
-        },
-        "javascript-lp-solver": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/javascript-lp-solver/-/javascript-lp-solver-0.4.24.tgz",
-            "integrity": "sha512-5edoDKnMrt/u3M6GnZKDDIPxOyFOg+WrwDv8mjNiMC2DePhy2H9/FFQgf4ggywaXT1utvkxusJcjQUER72cZmA=="
         },
         "jest": {
             "version": "27.3.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     },
     "dependencies": {
         "copyfiles": "^2.4.1",
-        "javascript-lp-solver": "^0.4.24",
         "tree-sitter": "^0.20.6",
         "tree-sitter-c-sharp": "^0.20.0",
         "tree-sitter-cpp": "^0.20.3",


### PR DESCRIPTION
Removes the seemingly not used javascript linear programming solver from the list of dependencies.
I could not find any usage of this.

Closes #27