### PR TITLE
Add contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ Branch names should follow the following structure: `<type>/<issue-id>/<name>`
 | `revert`    | Revert of some commit                  |
 | `style`     | Code style improvements                |
 | `refactor`  | Major refactorings                     |
+| `test`      | Adding or improving test cases         |
+| `perf`      | Performance optimizations              |
 | `tech`      | Other kinds of technical changes       |
 
 Examples:
@@ -46,13 +48,14 @@ Examples:
 
 Commit messages should follow the [Conventional Commits standard](https://www.conventionalcommits.org/en/v1.0.0/) with the following additional rules:
 
--   The first line MUST end with the id of the corresponding issue on GitHub
--   The type MUST be one of the types in the table "allowed change types" above
+-   The first line MUST end with the id of the corresponding issue on GitHub.
+-   The type MUST be one of the types in the table "allowed change types" above.
+-   Breaking changes MUST be indicated in the type/scope prefix of a commit by adding an exclamation mark `!` before the colon `:`.
 
 This results in the following structure for commit messages:
 
 ```
-<type>[optional scope]: <description> #<issue-id>
+<type>[optional scope][!]: <description> #<issue-id>
 
 [optional body]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,17 +27,19 @@ Branch names should follow the following structure: `<type>/<issue-id>/<name>`
 
 ### Allowed Change Types
 
-| Change Type | Description                            |
-| ----------- | -------------------------------------- |
-| `feat`      | Added new or expanded existing feature |
-| `fix`       | Bugfixes                               |
-| `docs`      | Updated documentation only             |
-| `revert`    | Revert of some commit                  |
-| `style`     | Code style improvements                |
-| `refactor`  | Major refactorings                     |
-| `test`      | Adding or improving test cases         |
-| `perf`      | Performance optimizations              |
-| `tech`      | Other kinds of technical changes       |
+| Change Type | Description                                    |
+| ----------- | ---------------------------------------------- |
+| `feat`      | Adds a new or expands an existing feature      |
+| `fix`       | Fixes a bug                                    |
+| `docs`      | Updates documentation only                     |
+| `style`     | Code style improvements, no logic changes      |
+| `refactor`  | Refactorings (neither "feat" nor "fix")        |
+| `perf`      | Performance optimizations                      |
+| `test`      | Adds or improves test cases                    |
+| `build`     | Build system or external dependency changes    |
+| `ci`        | Changes to the CI configuration or scripts     |
+| `chore`     | Other changes, do not modify src or test files |
+| `revert`    | Reverts a previous commit                      |
 
 Examples:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contribution Guidelines
+
+Thank you for your interest in contributing to our project :)<br>
+We like issue reports, suggestions and pull request from everyone.
+
+If you are planning to make a major contribution for which there is no existing issue, we would appreciate that you open an issue first.
+
+The following suggestions increase the chance that your pull request can be accepted:
+
+-   Write clean code
+-   Write tests for your new code
+-   Check that all tests are still passed
+-   Adhere to the naming conventions for branch names and commit messages mentioned below
+-   Avoid unnecessary breaking changes
+
+You and your code contribution has to adherence to the licence of this project.
+
+## Naming Conventions
+
+### Branch Names
+
+Branch names should follow the following structure: `<type>/<issue-id>/<name>`
+
+-   `<type>` is the type of the change (see table below).
+-   `<number>` is the number of the corresponding issue on GitHub the branch should resolve.
+-   `<name>` is a describing branch name, which should be in **lowercase** separated by **dashes**.
+
+### Allowed Change Types
+
+| Change Type | Description                            |
+| ----------- | -------------------------------------- |
+| `feat`      | Added new or expanded existing feature |
+| `fix`       | Bugfixes                               |
+| `docs`      | Updated documentation only             |
+| `revert`    | Revert of some commit                  |
+| `style`     | Code style improvements                |
+| `refactor`  | Major refactorings                     |
+| `tech`      | Other kinds of technical changes       |
+
+Examples:
+
+-   `feat/123/settings-option-xyz`
+-   `fix/124/unexpected-settings-error`
+
+### Commit Messages
+
+Commit messages should follow the [Conventional Commits standard](https://www.conventionalcommits.org/en/v1.0.0/) with the following additional rules:
+
+-   The first line MUST end with the id of the corresponding issue on GitHub
+-   The type MUST be one of the types in the table "allowed change types" above
+
+This results in the following structure for commit messages:
+
+```
+<type>[optional scope]: <description> #<issue-id>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+#### Examples for acceptable commit messages:
+
+-   `fix: wrong expected result in test case for java #1`
+-   `feat: records are now supported for C# #2`
+-   ```
+    feat!: change format of the json output #3
+
+    Introduced new field named info that might break code which works with our json output
+    ```
+
+-   `tech: improve handling of errors in GenericParser.ts #4`

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This is quite slow and can take up to one or two hours but can provide good resu
 
 ### Main Issues with MetricGardener
 
--   It is not very well tested.
--   The performance is very bad currently.
+1.  It is not very well tested
+2.  Because of 1., there might be some issues for certain languages
+3.  The list of supported languages is still rather limited
 
 ### Usage
 
@@ -78,6 +79,10 @@ Activate dependency analysis by passing `--parseDependencies`
 ### Updating tree-sitter grammars and adding support for more languages
 
 Take a look at UPDATE_GRAMMARS.md for further information on what to do if you have updated the tree-sitter grammars installed as dependency of this project. You also find information about adding support for an additional programming language there.
+
+### For contributors
+
+Check out our contribution guidelines in the file CONTRIBUTING.md.
 
 ### Enable debug prints
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Take a look at UPDATE_GRAMMARS.md for further information on what to do if you h
 
 ### For contributors
 
-Check out our contribution guidelines in the file CONTRIBUTING.md.
+Check out our contribution guidelines in the file [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Enable debug prints
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Activate dependency analysis by passing `--parseDependencies`
 
 ### Updating tree-sitter grammars and adding support for more languages
 
-Take a look at UPDATE_GRAMMARS.md for further information on what to do if you have updated the tree-sitter grammars installed as dependency of this project. You also find information about adding support for an additional programming language there.
+Take a look at [UPDATE_GRAMMARS.md](UPDATE_GRAMMARS.md) for further information on what to do if you have updated the tree-sitter grammars installed as dependency of this project. You also find information about adding support for an additional programming language there.
 
 ### For contributors
 


### PR DESCRIPTION
Adds a contribution guide similar to the one of CodeCharta, but adopting the Conventional Commits standard.

Closes #78 