### PR TITLE
Add new documentation for updating or adding grammars

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,19 +75,7 @@ Activate dependency analysis by passing `--parseDependencies`
 
 -   Multiple, nested Namespace Declarations within one .cs file are not covered so far and are ignored during the calculation of coupling.
 
-<<<<<<< Updated upstream
-
-### Maintenance of tree-sitter grammars
-
-=======
-
-### For contributors
-
-Check out our contribution guidelines in the file CONTRIBUTING.md.
-
 ### Updating tree-sitter grammars and adding support for more languages
-
-> > > > > > > Stashed changes
 
 Take a look at UPDATE_GRAMMARS.md for further information on what to do if you have updated the tree-sitter grammars installed as dependency of this project. You also find information about adding support for an additional programming language there.
 

--- a/README.md
+++ b/README.md
@@ -75,14 +75,21 @@ Activate dependency analysis by passing `--parseDependencies`
 
 -   Multiple, nested Namespace Declarations within one .cs file are not covered so far and are ignored during the calculation of coupling.
 
+<<<<<<< Updated upstream
+
 ### Maintenance of tree-sitter grammars
 
-Update grammars of programming languages to be up-to-date
-For this, reimport grammars for supported languages from tree-sitter by:
+=======
 
--   `npm run start -- import-grammars`
+### For contributors
 
-This will have no effect until you have mapped the changed and new expressions manually to ./src/parser/config/nodeTypesConfig.json
+Check out our contribution guidelines in the file CONTRIBUTING.md.
+
+### Updating tree-sitter grammars and adding support for more languages
+
+> > > > > > > Stashed changes
+
+Take a look at UPDATE_GRAMMARS.md for further information on what to do if you have updated the tree-sitter grammars installed as dependency of this project. You also find information about adding support for an additional programming language there.
 
 ### Enable debug prints
 

--- a/UPDATE_GRAMMARS.md
+++ b/UPDATE_GRAMMARS.md
@@ -1,0 +1,15 @@
+# Maintenance and addition of tree-sitter grammars
+
+## Updating grammars
+
+If you update the tree-sitter grammars installed as dependency of this project, you need to update the node types config file found under `./src/parser/config/nodeTypesConfig.json`.
+For this, reimport the grammars from all supported languages by running the import script:
+
+-   `npm run start -- import-grammars`
+
+If there are new syntax node types included in the grammars (e.g. because of a new feature of the corresponding programming language), these are still going to be ignored until you have mapped the new node types to the corresponding metric inside the `nodeTypesConfig.json`.
+
+## Adding support for a new programming language
+
+If you want to support a completely new programming language, you have to perform additional steps after installing the grammar as a dependency of this project and before running the import script. Add the language, the file extension(s) of the source code files used by that language and an appropriate shortcut for that language to the enum and the maps inside `./src/helper/Languages.ts`. You also have to add the path to the `node-types.json` of the tree-sitter grammar for that language to `./src/commands/ImportNodeTypes.ts`. After these steps, you can run the import script as mentioned above and run metric-gardener on source code of that newly added language afterwards. Note that metric-gardener can only consider the syntax node types that are already included in one of the already supported language when calculating metrics.
+For a correct and stable support of the language, you probably have to add mappings for language-specific syntax node types to the `nodeTypesConfig.json` and add test cases for that language. Perhaps you also have to include a special handling to the metrics calculation to accommodate for some language features.

--- a/UPDATE_GRAMMARS.md
+++ b/UPDATE_GRAMMARS.md
@@ -15,7 +15,7 @@ If you want to support a completely new programming language, you have to perfor
 
 -   Add the language, the file extension(s) of the source code files used by that language and an appropriate shortcut for that language to the enum and the maps inside `./src/helper/Languages.ts`.
 -   You also have to add the path to the `node-types.json` of the tree-sitter grammar for that language to `./src/commands/ImportNodeTypes.ts`.
--   After these steps, you can run the import script via `npm run start -- import-grammars` as mentioned above
+-   After these steps, you can run the import script via `npm run start -- import-grammars` as mentioned above.
 -   You can now run metric-gardener on source code of that newly added language.
 
 **Note:**

--- a/UPDATE_GRAMMARS.md
+++ b/UPDATE_GRAMMARS.md
@@ -11,5 +11,13 @@ If there are new syntax node types included in the grammars (e.g. because of a n
 
 ## Adding support for a new programming language
 
-If you want to support a completely new programming language, you have to perform additional steps after installing the grammar as a dependency of this project and before running the import script. Add the language, the file extension(s) of the source code files used by that language and an appropriate shortcut for that language to the enum and the maps inside `./src/helper/Languages.ts`. You also have to add the path to the `node-types.json` of the tree-sitter grammar for that language to `./src/commands/ImportNodeTypes.ts`. After these steps, you can run the import script as mentioned above and run metric-gardener on source code of that newly added language afterwards. Note that metric-gardener can only consider the syntax node types that are already included in one of the already supported language when calculating metrics.
+If you want to support a completely new programming language, you have to perform additional steps after installing the grammar as a dependency of this project and before running the import script:
+
+-   Add the language, the file extension(s) of the source code files used by that language and an appropriate shortcut for that language to the enum and the maps inside `./src/helper/Languages.ts`.
+-   You also have to add the path to the `node-types.json` of the tree-sitter grammar for that language to `./src/commands/ImportNodeTypes.ts`.
+-   After these steps, you can run the import script via `npm run start -- import-grammars` as mentioned above
+-   You can now run metric-gardener on source code of that newly added language.
+
+**Note:**
+metric-gardener can only consider the syntax node types that are already included in one of the already supported language when calculating metrics.
 For a correct and stable support of the language, you probably have to add mappings for language-specific syntax node types to the `nodeTypesConfig.json` and add test cases for that language. Perhaps you also have to include a special handling to the metrics calculation to accommodate for some language features.


### PR DESCRIPTION
Overhauled the documentation of updating grammars to reflect the current state of the import script and to add information about how to support a new programming language.

Moved this documentation to another markdown-file.

Closes #11