### PR TITLE
Style: fixed spelling mistake

### DIFF
--- a/src/parser/metrics/RealLinesOfCode.ts
+++ b/src/parser/metrics/RealLinesOfCode.ts
@@ -106,7 +106,7 @@ export class RealLinesOfCode implements Metric {
 
     isPythonMultilineComment(node: Parser.SyntaxNode) {
         // Multiline comments in python are (multiline) strings that are
-        // neither assigned to a variable nor used as call parameter.
+        // neither assigned to a variable nor used as a call parameter.
         return (
             node.type === "expression_statement" &&
             node.childCount === 1 &&


### PR DESCRIPTION
~~Removes the uneccesary parentheses around the boolean condition.~~ Prettier formatter does not like this

Corrects a spelling mistake.

Closes #82