### PR TITLE
Refactor test cases to reduce the times the parser is re-created

### DIFF
--- a/test/parser/CPlusPlusMetrics.test.ts
+++ b/test/parser/CPlusPlusMetrics.test.ts
@@ -1,68 +1,69 @@
-import { testFileMetric } from "./TestHelper";
-import { FileMetric } from "../../src/parser/metrics/Metric";
+import { expectFileMetric, parseAllFileMetrics } from "./TestHelper";
+import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("C++ metrics tests", () => {
     const cppTestResourcesPath = "./resources/c++/";
 
+    let results: Map<string, Map<string, MetricResult>>;
+
+    const testFileMetric = (inputPath, metric, expected) =>
+        expectFileMetric(results, inputPath, metric, expected);
+
+    beforeAll(async () => {
+        results = await parseAllFileMetrics(cppTestResourcesPath);
+    });
+
     describe("Parses C++ Complexity metric", () => {
-        it("should count correctly for a more complex, non-empty source code file", async () => {
-            await testFileMetric(
+        it("should count correctly for a more complex, non-empty source code file", () => {
+            testFileMetric(
                 cppTestResourcesPath + "cpp_example_code.cpp",
                 FileMetric.complexity,
                 10
             );
         });
 
-        it("should count correctly if the code format is really weird", async () => {
-            await testFileMetric(
-                cppTestResourcesPath + "weird_lines.cpp",
-                FileMetric.complexity,
-                10
-            );
+        it("should count correctly if the code format is really weird", () => {
+            testFileMetric(cppTestResourcesPath + "weird_lines.cpp", FileMetric.complexity, 10);
         });
 
-        it("should count correctly for a header with templates", async () => {
-            await testFileMetric(
-                cppTestResourcesPath + "helpful_templates.h",
-                FileMetric.complexity,
-                9
-            );
+        it("should count correctly for a header with templates", () => {
+            testFileMetric(cppTestResourcesPath + "helpful_templates.h", FileMetric.complexity, 9);
         });
 
-        it("should count all kinds of branching statements correctly, including nested ones", async () => {
-            await testFileMetric(cppTestResourcesPath + "branches.cpp", FileMetric.complexity, 12);
+        it("should count all kinds of branching statements correctly, including nested ones", () => {
+            testFileMetric(cppTestResourcesPath + "branches.cpp", FileMetric.complexity, 12);
         });
 
-        it("should count for two switch case labels and a function, but not for the default label", async () => {
-            await testFileMetric(
+        it("should count for two switch case labels and a function, but not for the default label",  () => {
+            testFileMetric(
                 cppTestResourcesPath + "switch_case.cpp",
                 FileMetric.complexity,
                 3
             );
         });
 
-        it("should count catch-statements and no return statements", async () => {
-            await testFileMetric(cppTestResourcesPath + "try_catch.cxx", FileMetric.complexity, 8);
+        it("should count catch-statements and no return statements", () => {
+            testFileMetric(cppTestResourcesPath + "try_catch.cxx", FileMetric.complexity, 8);
         });
 
-        it("should count SEH except blocks", async () => {
-            await testFileMetric(cppTestResourcesPath + "seh_except.cxx", FileMetric.complexity, 2);
+        it("should count SEH except blocks", () => {
+            testFileMetric(cppTestResourcesPath + "seh_except.cxx", FileMetric.complexity, 2);
         });
 
-        it("should not count class declarations", async () => {
-            await testFileMetric(cppTestResourcesPath + "classes.hpp", FileMetric.complexity, 0);
+        it("should not count class declarations", () => {
+            testFileMetric(cppTestResourcesPath + "classes.hpp", FileMetric.complexity, 0);
         });
 
-        it("should not count function declarations", async () => {
-            await testFileMetric(
+        it("should not count function declarations", () => {
+            testFileMetric(
                 cppTestResourcesPath + "function_declarations.hpp",
                 FileMetric.complexity,
                 0
             );
         });
 
-        it("should count function implementations", async () => {
-            await testFileMetric(
+        it("should count function implementations", () => {
+            testFileMetric(
                 cppTestResourcesPath + "function_implementations.cpp",
                 FileMetric.complexity,
                 6
@@ -71,128 +72,108 @@ describe("C++ metrics tests", () => {
     });
 
     describe("parses C++ classes metric", () => {
-        it("Should count all kinds of class declarations", async () => {
-            await testFileMetric(cppTestResourcesPath + "classes.hpp", FileMetric.classes, 11);
+        it("Should count all kinds of class declarations", () => {
+            testFileMetric(cppTestResourcesPath + "classes.hpp", FileMetric.classes, 11);
         });
 
-        it("should also count template class declarations", async () => {
-            await testFileMetric(
-                cppTestResourcesPath + "helpful_templates.h",
-                FileMetric.classes,
-                1
-            );
+        it("should also count template class declarations", () => {
+            testFileMetric(cppTestResourcesPath + "helpful_templates.h", FileMetric.classes, 1);
         });
 
-        it("should count classes correctly in a more typical header file", async () => {
-            await testFileMetric(
-                cppTestResourcesPath + "cpp_example_header.hpp",
-                FileMetric.classes,
-                2
-            );
+        it("should count classes correctly in a more typical header file", () => {
+            testFileMetric(cppTestResourcesPath + "cpp_example_header.hpp", FileMetric.classes, 2);
         });
 
-        it("should also count for structs", async () => {
-            await testFileMetric(cppTestResourcesPath + "structs.hpp", FileMetric.classes, 4);
+        it("should also count for structs", () => {
+            testFileMetric(cppTestResourcesPath + "structs.hpp", FileMetric.classes, 4);
         });
 
-        it("should also count class declarations in source code files", async () => {
-            await testFileMetric(cppTestResourcesPath + "source_class.cxx", FileMetric.classes, 1);
+        it("should also count class declarations in source code files", () => {
+            testFileMetric(cppTestResourcesPath + "source_class.cxx", FileMetric.classes, 1);
         });
     });
 
     describe("parses C++ functions metric", () => {
-        it("should count function implementations, including lambda functions", async () => {
-            await testFileMetric(
+        it("should count function implementations, including lambda functions", () => {
+            testFileMetric(
                 cppTestResourcesPath + "function_implementations.cpp",
                 FileMetric.functions,
                 6
             );
         });
 
-        it("should not count function declarations", async () => {
-            await testFileMetric(
+        it("should not count function declarations", () => {
+            testFileMetric(
                 cppTestResourcesPath + "function_declarations.hpp",
                 FileMetric.functions,
                 0
             );
         });
 
-        it("should count functions that are declared and implemented in a source file", async () => {
-            await testFileMetric(
-                cppTestResourcesPath + "source_class.cxx",
-                FileMetric.functions,
-                2
-            );
+        it("should count functions that are declared and implemented in a source file", () => {
+            testFileMetric(cppTestResourcesPath + "source_class.cxx", FileMetric.functions, 2);
         });
 
-        it("should count template functions", async () => {
-            await testFileMetric(
-                cppTestResourcesPath + "helpful_templates.h",
-                FileMetric.functions,
-                5
-            );
+        it("should count template functions", () => {
+            testFileMetric(cppTestResourcesPath + "helpful_templates.h", FileMetric.functions, 5);
         });
 
-        it("should count correctly in a more complex file, also counting for constructors", async () => {
-            await testFileMetric(
-                cppTestResourcesPath + "cpp_example_code.cpp",
-                FileMetric.functions,
-                9
-            );
+        it("should count correctly in a more complex file, also counting for constructors", () => {
+            testFileMetric(cppTestResourcesPath + "cpp_example_code.cpp", FileMetric.functions, 9);
         });
     });
 
     describe("parses C++ comment lines metric", () => {
-        it("should count inline, doxygen and block comments correctly", async () => {
-            await testFileMetric(cppTestResourcesPath + "comments.cc", FileMetric.commentLines, 14);
+        it("should count inline, doxygen and block comments correctly", () => {
+            testFileMetric(cppTestResourcesPath + "comments.cc", FileMetric.commentLines, 14);
         });
     });
 
     describe("parses C++ lines of code metric", () => {
-        it("should count the lines of code correctly for a non-empty file", async () => {
-            await testFileMetric(
+        it("should count the lines of code correctly for a non-empty file", () => {
+            testFileMetric(
                 cppTestResourcesPath + "cpp_example_code.cpp",
                 FileMetric.linesOfCode,
                 67
             );
         });
 
-        it("should count one line for an empty file", async () => {
-            await testFileMetric(cppTestResourcesPath + "empty.cxx", FileMetric.linesOfCode, 1);
+        it("should count one line for an empty file", () => {
+            testFileMetric(cppTestResourcesPath + "empty.cxx", FileMetric.linesOfCode, 1);
         });
     });
 
     describe("parses C++ real lines of code metric", () => {
-        it("should count correctly for a non-empty file, ignoring comments and empty lines", async () => {
-            await testFileMetric(
+        it("should count correctly for a non-empty file, ignoring comments and empty lines", () => {
+            testFileMetric(
                 cppTestResourcesPath + "cpp_example_code.cpp",
                 FileMetric.realLinesOfCode,
                 45
             );
         });
 
-        it("should count correctly for an empty file", async () => {
-            await testFileMetric(cppTestResourcesPath + "empty.cxx", FileMetric.realLinesOfCode, 0);
+        it("should count correctly for an empty file", () => {
+            testFileMetric(cppTestResourcesPath + "empty.cxx", FileMetric.realLinesOfCode, 0);
         });
 
-        it("should count correctly for a header file", async () => {
-            await testFileMetric(
+        it("should count correctly for a header file", () => {
+            testFileMetric(
                 cppTestResourcesPath + "cpp_example_header.hpp",
                 FileMetric.realLinesOfCode,
                 31
             );
         });
 
-        it("should count correctly if there are comments in the same line as actual code", async () => {
-            await testFileMetric(
+        it("should count correctly if there are comments in the same line as actual code", () => {
+            testFileMetric(
                 cppTestResourcesPath + "same_line_comment.cpp",
                 FileMetric.realLinesOfCode,
                 4
             );
         });
 
-        it("should count correctly if the code format is really weird", async () => {
-            await testFileMetric(
+        it("should count correctly if the code format is really weird", () => {
+            testFileMetric(
                 cppTestResourcesPath + "weird_lines.cpp",
                 FileMetric.realLinesOfCode,
                 89

--- a/test/parser/CPlusPlusMetrics.test.ts
+++ b/test/parser/CPlusPlusMetrics.test.ts
@@ -34,12 +34,8 @@ describe("C++ metrics tests", () => {
             testFileMetric(cppTestResourcesPath + "branches.cpp", FileMetric.complexity, 12);
         });
 
-        it("should count for two switch case labels and a function, but not for the default label",  () => {
-            testFileMetric(
-                cppTestResourcesPath + "switch_case.cpp",
-                FileMetric.complexity,
-                3
-            );
+        it("should count for two switch case labels and a function, but not for the default label", () => {
+            testFileMetric(cppTestResourcesPath + "switch_case.cpp", FileMetric.complexity, 3);
         });
 
         it("should count catch-statements and no return statements", () => {

--- a/test/parser/CSharpMetrics.test.ts
+++ b/test/parser/CSharpMetrics.test.ts
@@ -1,8 +1,17 @@
-import { getCouplingMetrics, testFileMetric } from "./TestHelper";
-import { FileMetric } from "../../src/parser/metrics/Metric";
+import { expectFileMetric, getCouplingMetrics, parseAllFileMetrics } from "./TestHelper";
+import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("C# metric tests", () => {
     const csharpTestResourcesPath = "./resources/c-sharp/";
+
+    let results: Map<string, Map<string, MetricResult>>;
+
+    const testFileMetric = (inputPath, metric, expected) =>
+        expectFileMetric(results, inputPath, metric, expected);
+
+    beforeAll(async () => {
+        results = await parseAllFileMetrics(csharpTestResourcesPath);
+    });
 
     describe("parsing C# dependencies", () => {
         it("should calculate the right dependencies and coupling metrics", async () => {
@@ -14,48 +23,44 @@ describe("C# metric tests", () => {
     });
 
     describe("parses C# complexity metric", () => {
-        it("should count loops properly", async () => {
-            await testFileMetric(csharpTestResourcesPath + "loops.cs", FileMetric.complexity, 4);
+        it("should count loops properly", () => {
+            testFileMetric(csharpTestResourcesPath + "loops.cs", FileMetric.complexity, 4);
         });
 
-        it("should count if statements correctly", async () => {
-            await testFileMetric(
-                csharpTestResourcesPath + "if-statements.cs",
-                FileMetric.complexity,
-                11
-            );
+        it("should count if statements correctly", () => {
+            testFileMetric(csharpTestResourcesPath + "if-statements.cs", FileMetric.complexity, 11);
         });
 
-        it("should not count any class declaration", async () => {
-            await testFileMetric(csharpTestResourcesPath + "classes.cs", FileMetric.complexity, 1);
+        it("should not count any class declaration", () => {
+            testFileMetric(csharpTestResourcesPath + "classes.cs", FileMetric.complexity, 1);
         });
 
-        it("should count switch case labels, but no default labels", async () => {
-            await testFileMetric(
+        it("should count switch case labels, but no default labels", () => {
+            testFileMetric(
                 csharpTestResourcesPath + "case-statements.cs",
                 FileMetric.complexity,
                 4
             );
         });
 
-        it("should count functions and methods correctly", async () => {
-            await testFileMetric(
+        it("should count functions and methods correctly", () => {
+            testFileMetric(
                 csharpTestResourcesPath + "functions-and-methods.cs",
                 FileMetric.complexity,
                 8
             );
         });
 
-        it("should not count multiple return statements within functions and methods correctly", async () => {
-            await testFileMetric(
+        it("should not count multiple return statements within functions and methods correctly", () => {
+            testFileMetric(
                 csharpTestResourcesPath + "multiple-return-statements.cs",
                 FileMetric.complexity,
                 3
             );
         });
 
-        it("should count try-catch-finally properly by only counting the catch-block", async () => {
-            await testFileMetric(
+        it("should count try-catch-finally properly by only counting the catch-block", () => {
+            testFileMetric(
                 csharpTestResourcesPath + "throw-try-catch-finally.cs",
                 FileMetric.complexity,
                 1
@@ -64,17 +69,17 @@ describe("C# metric tests", () => {
     });
 
     describe("parses C# classes metric", () => {
-        it("should count class declarations", async () => {
-            await testFileMetric(csharpTestResourcesPath + "classes.cs", FileMetric.classes, 6);
+        it("should count class declarations", () => {
+            testFileMetric(csharpTestResourcesPath + "classes.cs", FileMetric.classes, 6);
         });
-        it("should count record declarations", async () => {
-            await testFileMetric(csharpTestResourcesPath + "records.cs", FileMetric.classes, 5);
+        it("should count record declarations", () => {
+            testFileMetric(csharpTestResourcesPath + "records.cs", FileMetric.classes, 5);
         });
     });
 
     describe("parses C# functions metric", () => {
-        it("should count functions and methods properly", async () => {
-            await testFileMetric(
+        it("should count functions and methods properly", () => {
+            testFileMetric(
                 csharpTestResourcesPath + "functions-and-methods.cs",
                 FileMetric.functions,
                 8
@@ -83,16 +88,12 @@ describe("C# metric tests", () => {
     });
 
     describe("parses C# commentLines metric", () => {
-        it("should count properly, also counting file header, class description and doc block tag comment lines", async () => {
-            await testFileMetric(
-                csharpTestResourcesPath + "comments.cs",
-                FileMetric.commentLines,
-                14
-            );
+        it("should count properly, also counting file header, class description and doc block tag comment lines", () => {
+            testFileMetric(csharpTestResourcesPath + "comments.cs", FileMetric.commentLines, 14);
         });
 
-        it("should count properly, also in the presence of multiple block comments in the same line", async () => {
-            await testFileMetric(
+        it("should count properly, also in the presence of multiple block comments in the same line", () => {
+            testFileMetric(
                 csharpTestResourcesPath + "same-line-comment.cs",
                 FileMetric.commentLines,
                 4
@@ -101,78 +102,66 @@ describe("C# metric tests", () => {
     });
 
     describe("parses C# lines of code metric", () => {
-        it("should count number of lines correctly for a non-empty file with empty last line", async () => {
-            await testFileMetric(
+        it("should count number of lines correctly for a non-empty file with empty last line", () => {
+            testFileMetric(
                 csharpTestResourcesPath + "c-sharp-example-code.cs",
                 FileMetric.linesOfCode,
                 28
             );
         });
 
-        it("should count number of lines correctly for a non-empty file with non-empty last line", async () => {
-            await testFileMetric(
+        it("should count number of lines correctly for a non-empty file with non-empty last line", () => {
+            testFileMetric(
                 csharpTestResourcesPath + "non-empty-last-line.cs",
                 FileMetric.linesOfCode,
                 27
             );
         });
 
-        it("should count number of lines correctly for an empty file", async () => {
-            await testFileMetric(csharpTestResourcesPath + "empty.cs", FileMetric.linesOfCode, 1);
+        it("should count number of lines correctly for an empty file", () => {
+            testFileMetric(csharpTestResourcesPath + "empty.cs", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with one non-empty line", async () => {
-            await testFileMetric(
-                csharpTestResourcesPath + "one-line.cs",
-                FileMetric.linesOfCode,
-                1
-            );
+        it("should count number of lines correctly for an file with one non-empty line", () => {
+            testFileMetric(csharpTestResourcesPath + "one-line.cs", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with just a line break", async () => {
-            await testFileMetric(
-                csharpTestResourcesPath + "line-break.cs",
-                FileMetric.linesOfCode,
-                2
-            );
+        it("should count number of lines correctly for an file with just a line break", () => {
+            testFileMetric(csharpTestResourcesPath + "line-break.cs", FileMetric.linesOfCode, 2);
         });
     });
 
     describe("parses C# real lines of code metric", () => {
-        it("should count correctly for a non-empty file, ignoring comments and empty lines", async () => {
-            await testFileMetric(
+        it("should count correctly for a non-empty file, ignoring comments and empty lines", () => {
+            testFileMetric(
                 csharpTestResourcesPath + "real-lines-of-code.cs",
                 FileMetric.realLinesOfCode,
                 8
             );
         });
 
-        it("should count correctly for an empty file", async () => {
-            await testFileMetric(
-                csharpTestResourcesPath + "empty.cs",
-                FileMetric.realLinesOfCode,
-                0
-            );
+        it("should count correctly for an empty file", () => {
+            testFileMetric(csharpTestResourcesPath + "empty.cs", FileMetric.realLinesOfCode, 0);
         });
 
-        it("should count correctly for a file with a single comment", async () => {
-            await testFileMetric(
+        it("should count correctly for a file with a single comment", () => {
+            testFileMetric(
                 csharpTestResourcesPath + "single-comment.cs",
                 FileMetric.realLinesOfCode,
                 0
             );
         });
 
-        it("should count correctly if there is a comment in the same line as actual code", async () => {
-            await testFileMetric(
+        it("should count correctly if there is a comment in the same line as actual code", () => {
+            testFileMetric(
                 csharpTestResourcesPath + "same-line-comment.cs",
                 FileMetric.realLinesOfCode,
                 3
             );
         });
 
-        it("should count weirdly formatted lines of code correctly", async () => {
-            await testFileMetric(
+        it("should count weirdly formatted lines of code correctly", () => {
+            testFileMetric(
                 csharpTestResourcesPath + "weird-lines.cs",
                 FileMetric.realLinesOfCode,
                 32

--- a/test/parser/GoMetrics.test.ts
+++ b/test/parser/GoMetrics.test.ts
@@ -1,62 +1,63 @@
-import { testFileMetric } from "./TestHelper";
-import { FileMetric } from "../../src/parser/metrics/Metric";
+import { expectFileMetric, parseAllFileMetrics, testFileMetric } from "./TestHelper";
+import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("Go metric tests", () => {
     const goTestResourcesPath = "./resources/go/";
 
+    let results: Map<string, Map<string, MetricResult>>;
+
+    const testFileMetric = (inputPath, metric, expected) =>
+        expectFileMetric(results, inputPath, metric, expected);
+
+    beforeAll(async () => {
+        results = await parseAllFileMetrics(goTestResourcesPath);
+    });
+
     describe("parses Go Complexity metric", () => {
-        it("should count if statements correctly", async () => {
-            await testFileMetric(
-                goTestResourcesPath + "if-statements.go",
-                FileMetric.complexity,
-                7
-            );
+        it("should count if statements correctly", () => {
+            testFileMetric(goTestResourcesPath + "if-statements.go", FileMetric.complexity, 7);
         });
 
-        it("should count functions and methods correctly", async () => {
-            await testFileMetric(
+        it("should count functions and methods correctly", () => {
+            testFileMetric(
                 goTestResourcesPath + "functions-and-methods.go",
                 FileMetric.complexity,
                 2
             );
         });
 
-        it("should not count multiple return statements within functions and methods correctly", async () => {
-            await testFileMetric(
+        it("should not count multiple return statements within functions and methods correctly", () => {
+            testFileMetric(
                 goTestResourcesPath + "multiple-return-statements.go",
                 FileMetric.complexity,
                 3
             );
         });
 
-        it("should not count any class declaration", async () => {
-            await testFileMetric(goTestResourcesPath + "classes.go", FileMetric.complexity, 0);
+        it("should not count any class declaration", () => {
+            testFileMetric(goTestResourcesPath + "classes.go", FileMetric.complexity, 0);
         });
 
-        it("should count case statements correctly", async () => {
-            await testFileMetric(
-                goTestResourcesPath + "case-statements.go",
-                FileMetric.complexity,
-                3
-            );
+        it("should count case statements correctly", () => {
+            testFileMetric(goTestResourcesPath + "case-statements.go", FileMetric.complexity, 3);
         });
 
-        it("should count try-catch-finally properly", async () => {
-            await testFileMetric(
+        it("should count try-catch-finally properly", () => {
+            testFileMetric(
                 goTestResourcesPath + "throw-try-catch-finally.go",
                 FileMetric.complexity,
                 0
             );
         });
 
-        it("should count loops properly", async () => {
-            await testFileMetric(goTestResourcesPath + "loops.go", FileMetric.complexity, 4);
+        it("should count loops properly", () => {
+            testFileMetric(goTestResourcesPath + "loops.go", FileMetric.complexity, 4);
         });
     });
 
     describe("parses Go functions metric", () => {
-        it("should count functions and methods properly", async () => {
-            await testFileMetric(
+        it("should count functions and methods properly", () => {
+            testFileMetric(
                 goTestResourcesPath + "functions-and-methods.go",
                 FileMetric.functions,
                 2
@@ -68,8 +69,8 @@ describe("Go metric tests", () => {
         it(
             "should count number of comment lines correctly, including line with curly brackets, inline comments" +
                 " and lines of the block comment",
-            async () => {
-                await testFileMetric(
+            () => {
+                testFileMetric(
                     goTestResourcesPath + "if-statements.go",
                     FileMetric.commentLines,
                     6
@@ -77,60 +78,48 @@ describe("Go metric tests", () => {
             }
         );
 
-        it("should count number of comment lines correctly, including multiple successive comments", async () => {
-            await testFileMetric(
-                goTestResourcesPath + "go-example-code.go",
-                FileMetric.commentLines,
-                9
-            );
+        it("should count number of comment lines correctly, including multiple successive comments", () => {
+            testFileMetric(goTestResourcesPath + "go-example-code.go", FileMetric.commentLines, 9);
         });
     });
 
     describe("parses Go lines of code metric", () => {
-        it("should count number of lines correctly for a non-empty file with empty last line", async () => {
-            await testFileMetric(
-                goTestResourcesPath + "empty-last-line.go",
-                FileMetric.linesOfCode,
-                54
-            );
+        it("should count number of lines correctly for a non-empty file with empty last line", () => {
+            testFileMetric(goTestResourcesPath + "empty-last-line.go", FileMetric.linesOfCode, 54);
         });
 
-        it("should count number of lines correctly for a non-empty file with non-empty last line", async () => {
-            await testFileMetric(
-                goTestResourcesPath + "go-example-code.go",
-                FileMetric.linesOfCode,
-                53
-            );
+        it("should count number of lines correctly for a non-empty file with non-empty last line", () => {
+            testFileMetric(goTestResourcesPath + "go-example-code.go", FileMetric.linesOfCode, 53);
         });
 
-        it("should count number of lines correctly for an empty file", async () => {
-            await testFileMetric(goTestResourcesPath + "empty.go", FileMetric.linesOfCode, 1);
+        it("should count number of lines correctly for an empty file", () => {
+            testFileMetric(goTestResourcesPath + "empty.go", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with one non-empty line", async () => {
-            await testFileMetric(goTestResourcesPath + "one-line.go", FileMetric.linesOfCode, 1);
+        it("should count number of lines correctly for an file with one non-empty line", () => {
+            testFileMetric(goTestResourcesPath + "one-line.go", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with just a line break", async () => {
-            await testFileMetric(goTestResourcesPath + "line-break.go", FileMetric.linesOfCode, 2);
+        it("should count number of lines correctly for an file with just a line break", () => {
+            testFileMetric(goTestResourcesPath + "line-break.go", FileMetric.linesOfCode, 2);
         });
     });
 
     describe("parses Go real lines of code metric", () => {
-        it("should count correctly for a non-empty file, ignoring comments,  inline comments and empty lines", async () => {
-            await testFileMetric(
+        it("should count correctly for a non-empty file, ignoring comments,  inline comments and empty lines", () => {
+            testFileMetric(
                 goTestResourcesPath + "go-example-code.go",
                 FileMetric.realLinesOfCode,
                 32
             );
         });
 
-        it("should count correctly for an empty file", async () => {
-            await testFileMetric(goTestResourcesPath + "empty.go", FileMetric.realLinesOfCode, 0);
+        it("should count correctly for an empty file", () => {
+            testFileMetric(goTestResourcesPath + "empty.go", FileMetric.realLinesOfCode, 0);
         });
 
-        it("should count correctly if there is a comment that includes code", async () => {
-            await testFileMetric(
+        it("should count correctly if there is a comment that includes code", () => {
+            testFileMetric(
                 goTestResourcesPath + "if-statements.go",
                 FileMetric.realLinesOfCode,
                 19

--- a/test/parser/GoMetrics.test.ts
+++ b/test/parser/GoMetrics.test.ts
@@ -1,4 +1,4 @@
-import { expectFileMetric, parseAllFileMetrics, testFileMetric } from "./TestHelper";
+import { expectFileMetric, parseAllFileMetrics } from "./TestHelper";
 import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("Go metric tests", () => {

--- a/test/parser/JavaMetrics.test.ts
+++ b/test/parser/JavaMetrics.test.ts
@@ -1,35 +1,45 @@
-import { testFileMetric } from "./TestHelper";
-import { FileMetric } from "../../src/parser/metrics/Metric";
-const javaTestResourcesPath = "./resources/java/";
+import { expectFileMetric, parseAllFileMetrics } from "./TestHelper";
+import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("Java metrics tests.", () => {
+    const javaTestResourcesPath = "./resources/java/";
+
+    let results: Map<string, Map<string, MetricResult>>;
+
+    const testFileMetric = (inputPath, metric, expected) =>
+        expectFileMetric(results, inputPath, metric, expected);
+
+    beforeAll(async () => {
+        results = await parseAllFileMetrics(javaTestResourcesPath);
+    });
+
     describe("parses classes metric", () => {
-        it("should count classes with different access-modifier correctly", async () => {
-            await testFileMetric(
+        it("should count classes with different access-modifier correctly", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.classes + "/Classes.java",
                 FileMetric.classes,
                 2
             );
         });
 
-        it("should count the interface, class, abstract class and enum correctly", async () => {
-            await testFileMetric(
+        it("should count the interface, class, abstract class and enum correctly", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.classes + "/Classlike.java",
                 FileMetric.classes,
                 4
             );
         });
 
-        it("should count nested classes correctly", async () => {
-            await testFileMetric(
+        it("should count nested classes correctly", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.classes + "/NestedClasses.java",
                 FileMetric.classes,
                 4
             );
         });
 
-        it("should not count the fields or methods of a class correctly", async () => {
-            await testFileMetric(
+        it("should not count the fields or methods of a class correctly", () => {
+            testFileMetric(
                 javaTestResourcesPath +
                     "/" +
                     FileMetric.classes +
@@ -39,20 +49,20 @@ describe("Java metrics tests.", () => {
             );
         });
 
-        it("should count zero for an empty java file", async () => {
-            await testFileMetric(javaTestResourcesPath + "Empty.java", FileMetric.classes, 0);
+        it("should count zero for an empty java file", () => {
+            testFileMetric(javaTestResourcesPath + "Empty.java", FileMetric.classes, 0);
         });
 
-        it("should count zero for a file that contains only comments", async () => {
-            await testFileMetric(
+        it("should count zero for a file that contains only comments", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.classes + "/Comment.java",
                 FileMetric.classes,
                 0
             );
         });
 
-        it("should count all record declarations as classes", async () => {
-            await testFileMetric(
+        it("should count all record declarations as classes", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.classes + "/Person.java",
                 FileMetric.classes,
                 3
@@ -61,28 +71,28 @@ describe("Java metrics tests.", () => {
     });
 
     describe("parses lines of code metric", () => {
-        it("should count lines of code for a non-empty file correctly", async () => {
-            await testFileMetric(
+        it("should count lines of code for a non-empty file correctly", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.linesOfCode + "/ClassForLOC.java",
                 FileMetric.linesOfCode,
                 24
             );
         });
 
-        it("should count lines of code for an empty file correctly", async () => {
-            await testFileMetric(javaTestResourcesPath + "Empty.java", FileMetric.linesOfCode, 1);
+        it("should count lines of code for an empty file correctly", () => {
+            testFileMetric(javaTestResourcesPath + "Empty.java", FileMetric.linesOfCode, 1);
         });
 
-        it("should count lines of code correctly for a non-empty file that starts and ends with a line break", async () => {
-            await testFileMetric(
+        it("should count lines of code correctly for a non-empty file that starts and ends with a line break", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.linesOfCode + "/Linebreak.java",
                 FileMetric.linesOfCode,
                 7
             );
         });
 
-        it("should count lines of code for multiline strings, function calls, etc. correctly", async () => {
-            await testFileMetric(
+        it("should count lines of code for multiline strings, function calls, etc. correctly", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.linesOfCode + "/MultilineLineOfCode.java",
                 FileMetric.linesOfCode,
                 30
@@ -91,8 +101,8 @@ describe("Java metrics tests.", () => {
     });
 
     describe("parses real lines of code metric", () => {
-        it("should not count for comments", async () => {
-            await testFileMetric(
+        it("should not count for comments", () => {
+            testFileMetric(
                 javaTestResourcesPath +
                     "/" +
                     FileMetric.realLinesOfCode +
@@ -102,16 +112,16 @@ describe("Java metrics tests.", () => {
             );
         });
 
-        it("should count correctly if there is a comment in the same line as actual code", async () => {
-            await testFileMetric(
+        it("should count correctly if there is a comment in the same line as actual code", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.realLinesOfCode + "/InlineComment.java",
                 FileMetric.realLinesOfCode,
                 4
             );
         });
 
-        it("should count correctly if there is multi-line code", async () => {
-            await testFileMetric(
+        it("should count correctly if there is multi-line code", () => {
+            testFileMetric(
                 javaTestResourcesPath +
                     "/" +
                     FileMetric.realLinesOfCode +
@@ -121,8 +131,8 @@ describe("Java metrics tests.", () => {
             );
         });
 
-        it("should count the code lines in the initialization block", async () => {
-            await testFileMetric(
+        it("should count the code lines in the initialization block", () => {
+            testFileMetric(
                 javaTestResourcesPath +
                     "/" +
                     FileMetric.realLinesOfCode +
@@ -132,74 +142,70 @@ describe("Java metrics tests.", () => {
             );
         });
 
-        it("should count zero real lines of code for an empty file", async () => {
-            await testFileMetric(
-                javaTestResourcesPath + "Empty.java",
-                FileMetric.realLinesOfCode,
-                0
-            );
+        it("should count zero real lines of code for an empty file", () => {
+            testFileMetric(javaTestResourcesPath + "Empty.java", FileMetric.realLinesOfCode, 0);
         });
     });
 
     describe("parses functions metric", () => {
-        it("should count static and non-static function declarations correctly", async () => {
-            await testFileMetric(
+        it("should count static and non-static function declarations correctly", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.functions + "/StaticFuntions.java",
                 FileMetric.functions,
                 5
             );
         });
 
-        it("should count function declaration with different access-modifiers correctly", async () => {
-            await testFileMetric(
+        it("should count function declaration with different access-modifiers correctly", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.functions + "/FunctionAccessModifier.java",
                 FileMetric.functions,
                 4
             );
         });
 
-        it("should count constructors as function declaration", async () => {
-            await testFileMetric(
+        it("should count constructors as function declaration", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.functions + "/Constructor.java",
                 FileMetric.functions,
                 11
             );
         });
 
-        it("should count for function declarations in an interface", async () => {
-            await testFileMetric(
+        it("should count for function declarations in an interface", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.functions + "/InterfaceFunction.java",
                 FileMetric.functions,
                 2
             );
         });
 
-        it("should count function declarations in an abstract class", async () => {
-            await testFileMetric(
+        it("should count function declarations in an abstract class", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.functions + "/AbstractClassFunction.java",
                 FileMetric.functions,
                 2
             );
         });
 
-        it("should count overloading functions correctly", async () => {
-            await testFileMetric(
+        it("should count overloading functions correctly", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.functions + "/OverloadFuntion.java",
                 FileMetric.functions,
                 3
             );
         });
 
-        it("should count all function declarations and lambda expression", async () => {
-            await testFileMetric(
+        it("should count all function declarations and lambda expression", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.functions + "/LambdaExpression.java",
                 FileMetric.functions,
                 6
             );
         });
 
-        it("should count all record-constructors", async () => {
-            await testFileMetric(
+        it("should count all record-constructors", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.functions + "/RecordMethods.java",
                 FileMetric.functions,
                 3
@@ -215,56 +221,56 @@ describe("Java metrics tests.", () => {
     });
 
     describe("parses Complexity metric", () => {
-        it("should count one method declaration and its contained if-statements and logical operations correctly", async () => {
-            await testFileMetric(
+        it("should count one method declaration and its contained if-statements and logical operations correctly", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/IfStatements.java",
                 FileMetric.complexity,
                 8
             );
         });
 
-        it("should count one method declaration, the number of for- and while-statements and the containing logical operators correctly", async () => {
-            await testFileMetric(
+        it("should count one method declaration, the number of for- and while-statements and the containing logical operators correctly", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/WhileAndForLoop.java",
                 FileMetric.complexity,
                 11
             );
         });
 
-        it("should count one method declaration and all case labels, but no default-labels", async () => {
-            await testFileMetric(
+        it("should count one method declaration and all case labels, but no default-labels", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/SwitchStatement.java",
                 FileMetric.complexity,
                 8
             );
         });
 
-        it("should count all method declarations, if-statements and catch blocks, but not throw and finally blocks.", async () => {
-            await testFileMetric(
+        it("should count all method declarations, if-statements and catch blocks, but not throw and finally blocks.", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/TryCatchFinally.java",
                 FileMetric.complexity,
                 8
             );
         });
 
-        it("should count all method declarations and ternary operations", async () => {
-            await testFileMetric(
+        it("should count all method declarations and ternary operations", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/TernaryOperation.java",
                 FileMetric.complexity,
                 2
             );
         });
 
-        it("should count all method declarations (incl. lambda expressions) and for-loops, but not method references.", async () => {
-            await testFileMetric(
+        it("should count all method declarations (incl. lambda expressions) and for-loops, but not method references.", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/DifferentFunctions.java",
                 FileMetric.complexity,
                 5
             );
         });
 
-        it("should count logical operators and function declarations.", async () => {
-            await testFileMetric(
+        it("should count logical operators and function declarations.", () => {
+            testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/LogicalOperator.java",
                 FileMetric.complexity,
                 6
@@ -280,8 +286,8 @@ describe("Java metrics tests.", () => {
     });
 
     describe("parses comment-lines metric", () => {
-        it("should count the lines that contain inline, multi-line and single-line comments.", async () => {
-            await testFileMetric(
+        it("should count the lines that contain inline, multi-line and single-line comments.", () => {
+            testFileMetric(
                 javaTestResourcesPath +
                     "/" +
                     FileMetric.commentLines +

--- a/test/parser/JavaScriptMetrics.test.ts
+++ b/test/parser/JavaScriptMetrics.test.ts
@@ -1,68 +1,69 @@
-import { testFileMetric } from "./TestHelper";
-import { FileMetric } from "../../src/parser/metrics/Metric";
+import { expectFileMetric, parseAllFileMetrics } from "./TestHelper";
+import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("JavaScript metrics tests", () => {
     const jsTestResourcesPath = "./resources/javascript/";
 
+    let results: Map<string, Map<string, MetricResult>>;
+
+    const testFileMetric = (inputPath, metric, expected) =>
+        expectFileMetric(results, inputPath, metric, expected);
+
+    beforeAll(async () => {
+        results = await parseAllFileMetrics(jsTestResourcesPath);
+    });
+
     describe("parses JavaScript Complexity metric", () => {
-        it("should count if statements and logical operations (&& and ||) correctly", async () => {
-            await testFileMetric(
-                jsTestResourcesPath + "if-statements.js",
-                FileMetric.complexity,
-                7
-            );
+        it("should count if statements and logical operations (&& and ||) correctly", () => {
+            testFileMetric(jsTestResourcesPath + "if-statements.js", FileMetric.complexity, 7);
         });
 
-        it("should count functions and methods correctly", async () => {
-            await testFileMetric(
+        it("should count functions and methods correctly", () => {
+            testFileMetric(
                 jsTestResourcesPath + "functions-and-methods.js",
                 FileMetric.complexity,
                 8
             );
         });
 
-        it("should not count multiple return statements within functions and methods", async () => {
-            await testFileMetric(
+        it("should not count multiple return statements within functions and methods", () => {
+            testFileMetric(
                 jsTestResourcesPath + "multiple-return-statements.js",
                 FileMetric.complexity,
                 3
             );
         });
 
-        it("should not count any class declaration", async () => {
-            await testFileMetric(jsTestResourcesPath + "classes.js", FileMetric.complexity, 3);
+        it("should not count any class declaration", () => {
+            testFileMetric(jsTestResourcesPath + "classes.js", FileMetric.complexity, 3);
         });
 
-        it("should count case but no default statements correctly", async () => {
-            await testFileMetric(
-                jsTestResourcesPath + "case-statements.js",
-                FileMetric.complexity,
-                4
-            );
+        it("should count case but no default statements correctly", () => {
+            testFileMetric(jsTestResourcesPath + "case-statements.js", FileMetric.complexity, 4);
         });
 
-        it("should count try-catch-finally properly by only counting the catch-block", async () => {
-            await testFileMetric(
+        it("should count try-catch-finally properly by only counting the catch-block", () => {
+            testFileMetric(
                 jsTestResourcesPath + "throw-try-catch-finally.js",
                 FileMetric.complexity,
                 1
             );
         });
 
-        it("should count loops properly", async () => {
-            await testFileMetric(jsTestResourcesPath + "loops.js", FileMetric.complexity, 3);
+        it("should count loops properly", () => {
+            testFileMetric(jsTestResourcesPath + "loops.js", FileMetric.complexity, 3);
         });
     });
 
     describe("parses JavaScript classes metric", () => {
-        it("should count class declarations", async () => {
-            await testFileMetric(jsTestResourcesPath + "classes.js", FileMetric.classes, 3);
+        it("should count class declarations", () => {
+            testFileMetric(jsTestResourcesPath + "classes.js", FileMetric.classes, 3);
         });
     });
 
     describe("parses JavaScript functions metric", () => {
-        it("should count functions and methods properly", async () => {
-            await testFileMetric(
+        it("should count functions and methods properly", () => {
+            testFileMetric(
                 jsTestResourcesPath + "functions-and-methods.js",
                 FileMetric.functions,
                 8
@@ -72,19 +73,19 @@ describe("JavaScript metrics tests", () => {
 
     describe("parses JavaScript comment lines metric", () => {
         it("should count comments properly, also counting file header, class description, html and doc block tag comment lines", async () => {
-            await testFileMetric(jsTestResourcesPath + "comments.js", FileMetric.commentLines, 18);
+            testFileMetric(jsTestResourcesPath + "comments.js", FileMetric.commentLines, 18);
         });
 
-        it("should count comments properly, also in the presence of multiple block comments in the same line", async () => {
-            await testFileMetric(
+        it("should count comments properly, also in the presence of multiple block comments in the same line", () => {
+            testFileMetric(
                 jsTestResourcesPath + "same-line-comment.js",
                 FileMetric.commentLines,
                 4
             );
         });
 
-        it("should count comments properly, also counting multiline block comments starting in the same line as another comment", async () => {
-            await testFileMetric(
+        it("should count comments properly, also counting multiline block comments starting in the same line as another comment", () => {
+            testFileMetric(
                 jsTestResourcesPath + "consecutive-comments.js",
                 FileMetric.commentLines,
                 6
@@ -93,58 +94,50 @@ describe("JavaScript metrics tests", () => {
     });
 
     describe("parses JavaScript lines of code metric", () => {
-        it("should count number of lines correctly for a non-empty file with empty last line", async () => {
-            await testFileMetric(jsTestResourcesPath + "classes.js", FileMetric.linesOfCode, 24);
+        it("should count number of lines correctly for a non-empty file with empty last line", () => {
+            testFileMetric(jsTestResourcesPath + "classes.js", FileMetric.linesOfCode, 24);
         });
 
-        it("should count number of lines correctly for an empty file", async () => {
-            await testFileMetric(jsTestResourcesPath + "empty.js", FileMetric.linesOfCode, 1);
+        it("should count number of lines correctly for an empty file", () => {
+            testFileMetric(jsTestResourcesPath + "empty.js", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with one non-empty line", async () => {
-            await testFileMetric(jsTestResourcesPath + "one-line.js", FileMetric.linesOfCode, 1);
+        it("should count number of lines correctly for an file with one non-empty line", () => {
+            testFileMetric(jsTestResourcesPath + "one-line.js", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with just a line break", async () => {
-            await testFileMetric(jsTestResourcesPath + "line-break.js", FileMetric.linesOfCode, 2);
+        it("should count number of lines correctly for an file with just a line break", () => {
+            testFileMetric(jsTestResourcesPath + "line-break.js", FileMetric.linesOfCode, 2);
         });
     });
 
     describe("parses JavaScript real lines of code metric", () => {
-        it("should count correctly for a non-empty file, ignoring comments and empty lines", async () => {
-            await testFileMetric(
-                jsTestResourcesPath + "comments.js",
-                FileMetric.realLinesOfCode,
-                7
-            );
+        it("should count correctly for a non-empty file, ignoring comments and empty lines", () => {
+            testFileMetric(jsTestResourcesPath + "comments.js", FileMetric.realLinesOfCode, 7);
         });
 
-        it("should count correctly for an empty file", async () => {
-            await testFileMetric(jsTestResourcesPath + "empty.js", FileMetric.realLinesOfCode, 0);
+        it("should count correctly for an empty file", () => {
+            testFileMetric(jsTestResourcesPath + "empty.js", FileMetric.realLinesOfCode, 0);
         });
 
-        it("should count correctly for a file with a single comment", async () => {
-            await testFileMetric(
+        it("should count correctly for a file with a single comment", () => {
+            testFileMetric(
                 jsTestResourcesPath + "single-comment.js",
                 FileMetric.realLinesOfCode,
                 0
             );
         });
 
-        it("should count correctly if there is a comment in the same line as actual code", async () => {
-            await testFileMetric(
+        it("should count correctly if there is a comment in the same line as actual code", () => {
+            testFileMetric(
                 jsTestResourcesPath + "same-line-comment.js",
                 FileMetric.realLinesOfCode,
                 3
             );
         });
 
-        it("should count weirdly formatted lines of code correctly", async () => {
-            await testFileMetric(
-                jsTestResourcesPath + "weird-lines.js",
-                FileMetric.realLinesOfCode,
-                32
-            );
+        it("should count weirdly formatted lines of code correctly", () => {
+            testFileMetric(jsTestResourcesPath + "weird-lines.js", FileMetric.realLinesOfCode, 32);
         });
     });
 });

--- a/test/parser/KotlinMetrics.test.ts
+++ b/test/parser/KotlinMetrics.test.ts
@@ -1,52 +1,57 @@
-import { testFileMetric } from "./TestHelper";
-import { FileMetric } from "../../src/parser/metrics/Metric";
+import { expectFileMetric, parseAllFileMetrics, testFileMetric } from "./TestHelper";
+import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("Kotlin metric tests", () => {
     const kotlinTestResourcesPath = "./resources/kotlin/";
 
+    let results: Map<string, Map<string, MetricResult>>;
+
+    const testFileMetric = (inputPath, metric, expected) =>
+        expectFileMetric(results, inputPath, metric, expected);
+
+    beforeAll(async () => {
+        results = await parseAllFileMetrics(kotlinTestResourcesPath);
+    });
+
     describe("parses Kotlin complexity metric", () => {
-        it("should count loops properly", async () => {
-            await testFileMetric(kotlinTestResourcesPath + "loops.kt", FileMetric.complexity, 5);
+        it("should count loops properly", () => {
+            testFileMetric(kotlinTestResourcesPath + "loops.kt", FileMetric.complexity, 5);
         });
 
-        it("should count if statements and logical operations (&& and ||) correctly", async () => {
-            await testFileMetric(
-                kotlinTestResourcesPath + "if-statements.kt",
-                FileMetric.complexity,
-                10
-            );
+        it("should count if statements and logical operations (&& and ||) correctly", () => {
+            testFileMetric(kotlinTestResourcesPath + "if-statements.kt", FileMetric.complexity, 10);
         });
 
-        it("should not count any class declaration", async () => {
-            await testFileMetric(kotlinTestResourcesPath + "classes.kt", FileMetric.complexity, 4);
+        it("should not count any class declaration", () => {
+            testFileMetric(kotlinTestResourcesPath + "classes.kt", FileMetric.complexity, 4);
         });
 
         it("should count when case statements correctly, but not else statements", async () => {
-            await testFileMetric(
+            testFileMetric(
                 kotlinTestResourcesPath + "case-statements.kt",
                 FileMetric.complexity,
                 4
             );
         });
 
-        it("should count all function declarations and one init block correctly", async () => {
-            await testFileMetric(
+        it("should count all function declarations and one init block correctly", () => {
+            testFileMetric(
                 kotlinTestResourcesPath + "functions-and-methods.kt",
                 FileMetric.complexity,
                 11
             );
         });
 
-        it("should not count multiple return statements within functions and methods", async () => {
-            await testFileMetric(
+        it("should not count multiple return statements within functions and methods", () => {
+            testFileMetric(
                 kotlinTestResourcesPath + "multiple-return-statements.kt",
                 FileMetric.complexity,
                 3
             );
         });
 
-        it("should count try-catch-finally properly by only counting the catch-block", async () => {
-            await testFileMetric(
+        it("should count try-catch-finally properly by only counting the catch-block", () => {
+            testFileMetric(
                 kotlinTestResourcesPath + "throw-try-catch-finally.kt",
                 FileMetric.complexity,
                 3
@@ -55,14 +60,14 @@ describe("Kotlin metric tests", () => {
     });
 
     describe("parses Kotlin classes metric", () => {
-        it("should count class declarations", async () => {
-            await testFileMetric(kotlinTestResourcesPath + "classes.kt", FileMetric.classes, 8);
+        it("should count class declarations", () => {
+            testFileMetric(kotlinTestResourcesPath + "classes.kt", FileMetric.classes, 8);
         });
     });
 
     describe("parses Kotlin functions metric", () => {
-        it("should count functions and methods properly", async () => {
-            await testFileMetric(
+        it("should count functions and methods properly", () => {
+            testFileMetric(
                 kotlinTestResourcesPath + "functions-and-methods.kt",
                 FileMetric.functions,
                 10
@@ -71,16 +76,12 @@ describe("Kotlin metric tests", () => {
     });
 
     describe("parses Kotlin commentLines metric", () => {
-        it("should count properly, also counting file header, class description and doc block tag comment lines", async () => {
-            await testFileMetric(
-                kotlinTestResourcesPath + "comments.kt",
-                FileMetric.commentLines,
-                14
-            );
+        it("should count properly, also counting file header, class description and doc block tag comment lines", () => {
+            testFileMetric(kotlinTestResourcesPath + "comments.kt", FileMetric.commentLines, 14);
         });
 
-        it("should count properly, also in the presence of multiple block comments in the same line", async () => {
-            await testFileMetric(
+        it("should count properly, also in the presence of multiple block comments in the same line", () => {
+            testFileMetric(
                 kotlinTestResourcesPath + "same-line-comment.kt",
                 FileMetric.commentLines,
                 4
@@ -89,78 +90,66 @@ describe("Kotlin metric tests", () => {
     });
 
     describe("parses Kotlin lines of code metric", () => {
-        it("should count number of lines correctly for a non-empty file with empty last line", async () => {
-            await testFileMetric(
+        it("should count number of lines correctly for a non-empty file with empty last line", () => {
+            testFileMetric(
                 kotlinTestResourcesPath + "kotlin-example-code.kt",
                 FileMetric.linesOfCode,
                 62
             );
         });
 
-        it("should count number of lines correctly for a non-empty file with non-empty last line", async () => {
-            await testFileMetric(
+        it("should count number of lines correctly for a non-empty file with non-empty last line", () => {
+            testFileMetric(
                 kotlinTestResourcesPath + "kotlin-example-code-2.kt",
                 FileMetric.linesOfCode,
                 31
             );
         });
 
-        it("should count number of lines correctly for an empty file", async () => {
-            await testFileMetric(kotlinTestResourcesPath + "empty.kt", FileMetric.linesOfCode, 1);
+        it("should count number of lines correctly for an empty file", () => {
+            testFileMetric(kotlinTestResourcesPath + "empty.kt", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with one non-empty line", async () => {
-            await testFileMetric(
-                kotlinTestResourcesPath + "one-line.kt",
-                FileMetric.linesOfCode,
-                1
-            );
+        it("should count number of lines correctly for an file with one non-empty line", () => {
+            testFileMetric(kotlinTestResourcesPath + "one-line.kt", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with just a line break", async () => {
-            await testFileMetric(
-                kotlinTestResourcesPath + "line-break.kt",
-                FileMetric.linesOfCode,
-                2
-            );
+        it("should count number of lines correctly for an file with just a line break", () => {
+            testFileMetric(kotlinTestResourcesPath + "line-break.kt", FileMetric.linesOfCode, 2);
         });
     });
 
     describe("parses Kotlin real lines of code metric", () => {
-        it("should count correctly for a non-empty file, ignoring comments and empty lines", async () => {
-            await testFileMetric(
+        it("should count correctly for a non-empty file, ignoring comments and empty lines", () => {
+            testFileMetric(
                 kotlinTestResourcesPath + "kotlin-example-code.kt",
                 FileMetric.realLinesOfCode,
                 50
             );
         });
 
-        it("should count correctly for a non-empty file", async () => {
-            await testFileMetric(
+        it("should count correctly for a non-empty file", () => {
+            testFileMetric(
                 kotlinTestResourcesPath + "kotlin-example-code-2.kt",
                 FileMetric.realLinesOfCode,
                 31
             );
         });
 
-        it("should count correctly for an empty file", async () => {
-            await testFileMetric(
-                kotlinTestResourcesPath + "empty.kt",
-                FileMetric.realLinesOfCode,
-                0
-            );
+        it("should count correctly for an empty file", () => {
+            testFileMetric(kotlinTestResourcesPath + "empty.kt", FileMetric.realLinesOfCode, 0);
         });
 
-        it("should count correctly if there is a comment in the same line as actual code", async () => {
-            await testFileMetric(
+        it("should count correctly if there is a comment in the same line as actual code", () => {
+            testFileMetric(
                 kotlinTestResourcesPath + "same-line-comment.kt",
                 FileMetric.realLinesOfCode,
                 5
             );
         });
 
-        it("should count weirdly formatted lines of code correctly", async () => {
-            await testFileMetric(
+        it("should count weirdly formatted lines of code correctly", () => {
+            testFileMetric(
                 kotlinTestResourcesPath + "weird-lines.kt",
                 FileMetric.realLinesOfCode,
                 30

--- a/test/parser/KotlinMetrics.test.ts
+++ b/test/parser/KotlinMetrics.test.ts
@@ -1,4 +1,4 @@
-import { expectFileMetric, parseAllFileMetrics, testFileMetric } from "./TestHelper";
+import { expectFileMetric, parseAllFileMetrics } from "./TestHelper";
 import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("Kotlin metric tests", () => {

--- a/test/parser/PHPMetrics.test.ts
+++ b/test/parser/PHPMetrics.test.ts
@@ -1,9 +1,4 @@
-import {
-    expectFileMetric,
-    getCouplingMetrics,
-    parseAllFileMetrics,
-    testFileMetric,
-} from "./TestHelper";
+import { expectFileMetric, getCouplingMetrics, parseAllFileMetrics } from "./TestHelper";
 import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("PHP metrics tests", () => {

--- a/test/parser/PHPMetrics.test.ts
+++ b/test/parser/PHPMetrics.test.ts
@@ -1,68 +1,74 @@
-import { getCouplingMetrics, testFileMetric } from "./TestHelper";
-import { FileMetric } from "../../src/parser/metrics/Metric";
+import {
+    expectFileMetric,
+    getCouplingMetrics,
+    parseAllFileMetrics,
+    testFileMetric,
+} from "./TestHelper";
+import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("PHP metrics tests", () => {
     const phpTestResourcesPath = "./resources/php/";
 
+    let results: Map<string, Map<string, MetricResult>>;
+
+    const testFileMetric = (inputPath, metric, expected) =>
+        expectFileMetric(results, inputPath, metric, expected);
+
+    beforeAll(async () => {
+        results = await parseAllFileMetrics(phpTestResourcesPath);
+    });
+
     describe("parses PHP Complexity metric", () => {
-        it("should count branching statements correctly", async () => {
-            await testFileMetric(
-                phpTestResourcesPath + "if-statements.php",
-                FileMetric.complexity,
-                8
-            );
+        it("should count branching statements correctly", () => {
+            testFileMetric(phpTestResourcesPath + "if-statements.php", FileMetric.complexity, 8);
         });
 
-        it("should count functions and methods correctly", async () => {
-            await testFileMetric(
+        it("should count functions and methods correctly", () => {
+            testFileMetric(
                 phpTestResourcesPath + "functions-and-methods.php",
                 FileMetric.complexity,
                 7
             );
         });
 
-        it("should not count multiple return statements within functions and methods like sonar", async () => {
-            await testFileMetric(
+        it("should not count multiple return statements within functions and methods like sonar", () => {
+            testFileMetric(
                 phpTestResourcesPath + "multiple-return-statements.php",
                 FileMetric.complexity,
                 3
             );
         });
 
-        it("should not count any class declaration", async () => {
-            await testFileMetric(phpTestResourcesPath + "classes.php", FileMetric.complexity, 0);
+        it("should not count any class declaration", () => {
+            testFileMetric(phpTestResourcesPath + "classes.php", FileMetric.complexity, 0);
         });
 
-        it("should count case statements correctly", async () => {
-            await testFileMetric(
-                phpTestResourcesPath + "case-statements.php",
-                FileMetric.complexity,
-                3
-            );
+        it("should count case statements correctly", () => {
+            testFileMetric(phpTestResourcesPath + "case-statements.php", FileMetric.complexity, 3);
         });
 
-        it("should count try-catch-finally properly by only counting the catch-block", async () => {
-            await testFileMetric(
+        it("should count try-catch-finally properly by only counting the catch-block", () => {
+            testFileMetric(
                 phpTestResourcesPath + "throw-try-catch-finally.php",
                 FileMetric.complexity,
                 1
             );
         });
 
-        it("should count loops properly", async () => {
-            await testFileMetric(phpTestResourcesPath + "loops.php", FileMetric.complexity, 4);
+        it("should count loops properly", () => {
+            testFileMetric(phpTestResourcesPath + "loops.php", FileMetric.complexity, 4);
         });
     });
 
     describe("parses PHP classes metric", () => {
-        it("should count class declarations", async () => {
-            await testFileMetric(phpTestResourcesPath + "classes.php", FileMetric.classes, 3);
+        it("should count class declarations", () => {
+            testFileMetric(phpTestResourcesPath + "classes.php", FileMetric.classes, 3);
         });
     });
 
     describe("parses PHP functions metric", () => {
-        it("should count function declarations", async () => {
-            await testFileMetric(
+        it("should count function declarations", () => {
+            testFileMetric(
                 phpTestResourcesPath + "functions-and-methods.php",
                 FileMetric.functions,
                 7
@@ -71,54 +77,50 @@ describe("PHP metrics tests", () => {
     });
 
     describe("parses PHP lines of code metric", () => {
-        it("should count number of lines correctly for a non-empty file with empty last line", async () => {
-            await testFileMetric(
+        it("should count number of lines correctly for a non-empty file with empty last line", () => {
+            testFileMetric(
                 phpTestResourcesPath + "empty-last-line.php",
                 FileMetric.linesOfCode,
                 66
             );
         });
 
-        it("should count number of lines correctly for a non-empty file with non-empty last line", async () => {
-            await testFileMetric(
+        it("should count number of lines correctly for a non-empty file with non-empty last line", () => {
+            testFileMetric(
                 phpTestResourcesPath + "php-example-code.php",
                 FileMetric.linesOfCode,
                 65
             );
         });
 
-        it("should count number of lines correctly for an empty file", async () => {
-            await testFileMetric(phpTestResourcesPath + "empty.php", FileMetric.linesOfCode, 1);
+        it("should count number of lines correctly for an empty file", () => {
+            testFileMetric(phpTestResourcesPath + "empty.php", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with one non-empty line", async () => {
-            await testFileMetric(phpTestResourcesPath + "one-line.php", FileMetric.linesOfCode, 1);
+        it("should count number of lines correctly for an file with one non-empty line", () => {
+            testFileMetric(phpTestResourcesPath + "one-line.php", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with just a line break", async () => {
-            await testFileMetric(
-                phpTestResourcesPath + "line-break.php",
-                FileMetric.linesOfCode,
-                2
-            );
+        it("should count number of lines correctly for an file with just a line break", () => {
+            testFileMetric(phpTestResourcesPath + "line-break.php", FileMetric.linesOfCode, 2);
         });
     });
 
     describe("parses PHP real lines of code metric", () => {
-        it("should count correctly for a non-empty file, ignoring comments and empty lines", async () => {
-            await testFileMetric(
+        it("should count correctly for a non-empty file, ignoring comments and empty lines", () => {
+            testFileMetric(
                 phpTestResourcesPath + "php-example-code.php",
                 FileMetric.realLinesOfCode,
                 43
             );
         });
 
-        it("should count correctly for an empty file", async () => {
-            await testFileMetric(phpTestResourcesPath + "empty.php", FileMetric.realLinesOfCode, 0);
+        it("should count correctly for an empty file", () => {
+            testFileMetric(phpTestResourcesPath + "empty.php", FileMetric.realLinesOfCode, 0);
         });
 
-        it("should count correctly if there is a comment in the same line as actual code", async () => {
-            await testFileMetric(
+        it("should count correctly if there is a comment in the same line as actual code", () => {
+            testFileMetric(
                 phpTestResourcesPath + "same-line-comment.php",
                 FileMetric.realLinesOfCode,
                 11
@@ -130,8 +132,8 @@ describe("PHP metrics tests", () => {
         it(
             "should count number of comment lines correctly, including line with curly brackets and comment " +
                 "lines inside block comment",
-            async () => {
-                await testFileMetric(
+            () => {
+                testFileMetric(
                     phpTestResourcesPath + "php-example-code.php",
                     FileMetric.commentLines,
                     12

--- a/test/parser/PythonMetrics.test.ts
+++ b/test/parser/PythonMetrics.test.ts
@@ -1,52 +1,57 @@
-import { testFileMetric } from "./TestHelper";
-import { FileMetric } from "../../src/parser/metrics/Metric";
+import { expectFileMetric, parseAllFileMetrics } from "./TestHelper";
+import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("Python metrics test", () => {
     const pythonTestResourcesPath = "./resources/python/";
 
+    let results: Map<string, Map<string, MetricResult>>;
+
+    const testFileMetric = (inputPath, metric, expected) =>
+        expectFileMetric(results, inputPath, metric, expected);
+
+    beforeAll(async () => {
+        results = await parseAllFileMetrics(pythonTestResourcesPath);
+    });
+
     describe("parses Python Complexity metric", () => {
-        it("should count loops properly", async () => {
-            await testFileMetric(pythonTestResourcesPath + "loops.py", FileMetric.complexity, 4);
+        it("should count loops properly", () => {
+            testFileMetric(pythonTestResourcesPath + "loops.py", FileMetric.complexity, 4);
         });
 
-        it("should count if statements correctly", async () => {
-            await testFileMetric(
-                pythonTestResourcesPath + "if-statements.py",
-                FileMetric.complexity,
-                6
-            );
+        it("should count if statements correctly", () => {
+            testFileMetric(pythonTestResourcesPath + "if-statements.py", FileMetric.complexity, 6);
         });
 
-        it("should not count any class declaration", async () => {
-            await testFileMetric(pythonTestResourcesPath + "classes.py", FileMetric.complexity, 1);
+        it("should not count any class declaration", () => {
+            testFileMetric(pythonTestResourcesPath + "classes.py", FileMetric.complexity, 1);
         });
 
-        it("should count switch case labels, but no default labels", async () => {
-            await testFileMetric(
+        it("should count switch case labels, but no default labels", () => {
+            testFileMetric(
                 pythonTestResourcesPath + "case-statements.py",
                 FileMetric.complexity,
                 3
             );
         });
 
-        it("should count functions and methods correctly", async () => {
-            await testFileMetric(
+        it("should count functions and methods correctly", () => {
+            testFileMetric(
                 pythonTestResourcesPath + "functions-and-methods.py",
                 FileMetric.complexity,
                 6
             );
         });
 
-        it("should not count multiple return statements within functions and methods correctly", async () => {
-            await testFileMetric(
+        it("should not count multiple return statements within functions and methods correctly", () => {
+            testFileMetric(
                 pythonTestResourcesPath + "multiple-return-statements.py",
                 FileMetric.complexity,
                 3
             );
         });
 
-        it("should count try-catch-finally properly by only counting the catch-block", async () => {
-            await testFileMetric(
+        it("should count try-catch-finally properly by only counting the catch-block", () => {
+            testFileMetric(
                 pythonTestResourcesPath + "throw-try-catch-finally.py",
                 FileMetric.complexity,
                 2
@@ -55,14 +60,14 @@ describe("Python metrics test", () => {
     });
 
     describe("parses Python classes metric", () => {
-        it("should count class declarations", async () => {
-            await testFileMetric(pythonTestResourcesPath + "classes.py", FileMetric.classes, 4);
+        it("should count class declarations", () => {
+            testFileMetric(pythonTestResourcesPath + "classes.py", FileMetric.classes, 4);
         });
     });
 
     describe("parses Python functions metric", () => {
-        it("should count functions and methods properly", async () => {
-            await testFileMetric(
+        it("should count functions and methods properly", () => {
+            testFileMetric(
                 pythonTestResourcesPath + "functions-and-methods.py",
                 FileMetric.functions,
                 6
@@ -71,80 +76,52 @@ describe("Python metrics test", () => {
     });
 
     describe("parses Python comment lines metric", () => {
-        it("should count correctly, including inline and block comments", async () => {
-            await testFileMetric(
+        it("should count correctly, including inline and block comments", () => {
+            testFileMetric(
                 pythonTestResourcesPath + "block-comment.py",
                 FileMetric.commentLines,
                 7
             );
         });
 
-        it("should count properly, also counting file header, class description and doc block tag comment lines", async () => {
-            await testFileMetric(
-                pythonTestResourcesPath + "comments.py",
-                FileMetric.commentLines,
-                11
-            );
+        it("should count properly, also counting file header, class description and doc block tag comment lines", () => {
+            testFileMetric(pythonTestResourcesPath + "comments.py", FileMetric.commentLines, 11);
         });
     });
 
     describe("parses Python lines of code metric", () => {
-        it("should count number of lines correctly for a non-empty file with non-empty last line", async () => {
-            await testFileMetric(
-                pythonTestResourcesPath + "classes.py",
-                FileMetric.linesOfCode,
-                19
-            );
+        it("should count number of lines correctly for a non-empty file with non-empty last line", () => {
+            testFileMetric(pythonTestResourcesPath + "classes.py", FileMetric.linesOfCode, 19);
         });
 
-        it("should count number of lines correctly for an empty file", async () => {
-            await testFileMetric(pythonTestResourcesPath + "empty.py", FileMetric.linesOfCode, 1);
+        it("should count number of lines correctly for an empty file", () => {
+            testFileMetric(pythonTestResourcesPath + "empty.py", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with one non-empty line", async () => {
-            await testFileMetric(
-                pythonTestResourcesPath + "one-line.py",
-                FileMetric.linesOfCode,
-                1
-            );
+        it("should count number of lines correctly for an file with one non-empty line", () => {
+            testFileMetric(pythonTestResourcesPath + "one-line.py", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with just a line break", async () => {
-            await testFileMetric(
-                pythonTestResourcesPath + "line-break.py",
-                FileMetric.linesOfCode,
-                2
-            );
+        it("should count number of lines correctly for an file with just a line break", () => {
+            testFileMetric(pythonTestResourcesPath + "line-break.py", FileMetric.linesOfCode, 2);
         });
     });
 
     describe("parses Python real lines of code metric", () => {
-        it("should count correctly for a non-empty file with pythons non-C-syntax code blocks", async () => {
-            await testFileMetric(
-                pythonTestResourcesPath + "blocks.py",
-                FileMetric.realLinesOfCode,
-                9
-            );
+        it("should count correctly for a non-empty file with pythons non-C-syntax code blocks", () => {
+            testFileMetric(pythonTestResourcesPath + "blocks.py", FileMetric.realLinesOfCode, 9);
         });
 
-        it("should count correctly for an empty file", async () => {
-            await testFileMetric(
-                pythonTestResourcesPath + "empty.py",
-                FileMetric.realLinesOfCode,
-                0
-            );
+        it("should count correctly for an empty file", () => {
+            testFileMetric(pythonTestResourcesPath + "empty.py", FileMetric.realLinesOfCode, 0);
         });
 
-        it("should count correctly for a non-empty file with nested loops and comments", async () => {
-            await testFileMetric(
-                pythonTestResourcesPath + "loops.py",
-                FileMetric.realLinesOfCode,
-                8
-            );
+        it("should count correctly for a non-empty file with nested loops and comments", () => {
+            testFileMetric(pythonTestResourcesPath + "loops.py", FileMetric.realLinesOfCode, 8);
         });
 
-        it("should count correctly in the presence of block comments", async () => {
-            await testFileMetric(
+        it("should count correctly in the presence of block comments", () => {
+            testFileMetric(
                 pythonTestResourcesPath + "block-comment.py",
                 FileMetric.realLinesOfCode,
                 3

--- a/test/parser/TestHelper.ts
+++ b/test/parser/TestHelper.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { GenericParser } from "../../src/parser/GenericParser";
 import { Configuration } from "../../src/parser/Configuration";
-import { CouplingResult, FileMetric } from "../../src/parser/metrics/Metric";
+import { CouplingResult, FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 import { strcmp } from "../../src/parser/helper/Helper";
 
 /**
@@ -61,6 +61,35 @@ export async function testFileMetric(inputPath: string, metric: FileMetric, expe
     const parser = new GenericParser(getParserConfiguration(realInputPath));
     const results = await parser.calculateMetrics();
     expect(results.fileMetrics.get(realInputPath)?.get(metric)?.metricValue).toBe(expected);
+}
+
+/**
+ * Calculates all file metrics for all supported files that can be found under the specified input path.
+ * @param inputPath Path to the source code files to parse.
+ * @return Map that maps the absolute file paths to the corresponding map of calculated file metric results.
+ */
+export async function parseAllFileMetrics(inputPath: string) {
+    const realInputPath = fs.realpathSync(inputPath);
+    const parser = new GenericParser(getParserConfiguration(realInputPath));
+    return (await parser.calculateMetrics()).fileMetrics;
+}
+
+/**
+ * Tests if a specific metric for a specific source file has been calculated correctly.
+ * @param results The actual results of the metric calculation.
+ * Assumes that this map uses the absolute paths to the source files.
+ * @param inputPath Relative or absolute path to test source file.
+ * @param metric Name of the metric.
+ * @param expected Expected metric value.
+ * */
+export function expectFileMetric(
+    results: Map<string, Map<string, MetricResult>>,
+    inputPath: string,
+    metric: FileMetric,
+    expected: number
+) {
+    const realInputPath = fs.realpathSync(inputPath);
+    expect(results.get(realInputPath)?.get(metric)?.metricValue).toBe(expected);
 }
 
 /**

--- a/test/parser/TestHelper.ts
+++ b/test/parser/TestHelper.ts
@@ -51,12 +51,17 @@ export function sortCouplingResults(couplingResult: CouplingResult) {
 }
 
 /**
+ * Invokes the calculation of the file metrics for the specified file.
  * Tests if the file metric is calculated correctly.
- * @param inputPath Path to test source files.
+ * @param inputPath Path to test source file.
  * @param metric Name of the metric.
  * @param expected Expected test result.
  * */
-export async function testFileMetric(inputPath: string, metric: FileMetric, expected: number) {
+export async function parseAndTestFileMetric(
+    inputPath: string,
+    metric: FileMetric,
+    expected: number
+) {
     const realInputPath = fs.realpathSync(inputPath);
     const parser = new GenericParser(getParserConfiguration(realInputPath));
     const results = await parser.calculateMetrics();

--- a/test/parser/TypeScriptMetrics.test.ts
+++ b/test/parser/TypeScriptMetrics.test.ts
@@ -1,68 +1,69 @@
-import { testFileMetric } from "./TestHelper";
-import { FileMetric } from "../../src/parser/metrics/Metric";
+import { expectFileMetric, parseAllFileMetrics, testFileMetric } from "./TestHelper";
+import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("TypeScript metrics tests", () => {
     const tsTestResourcesPath = "./resources/typescript/";
 
+    let results: Map<string, Map<string, MetricResult>>;
+
+    const testFileMetric = (inputPath, metric, expected) =>
+        expectFileMetric(results, inputPath, metric, expected);
+
+    beforeAll(async () => {
+        results = await parseAllFileMetrics(tsTestResourcesPath);
+    });
+
     describe("parses TypeScript Complexity metric", () => {
-        it("should count if statements correctly", async () => {
-            await testFileMetric(
-                tsTestResourcesPath + "if-statements.ts",
-                FileMetric.complexity,
-                8
-            );
+        it("should count if statements correctly", () => {
+            testFileMetric(tsTestResourcesPath + "if-statements.ts", FileMetric.complexity, 8);
         });
 
-        it("should count functions and methods correctly", async () => {
-            await testFileMetric(
+        it("should count functions and methods correctly", () => {
+            testFileMetric(
                 tsTestResourcesPath + "functions-and-methods.ts",
                 FileMetric.complexity,
                 9
             );
         });
 
-        it("should not count multiple return statements within functions and methods correctly", async () => {
-            await testFileMetric(
+        it("should not count multiple return statements within functions and methods correctly", () => {
+            testFileMetric(
                 tsTestResourcesPath + "multiple-return-statements.ts",
                 FileMetric.complexity,
                 3
             );
         });
 
-        it("should not count any class declaration", async () => {
-            await testFileMetric(tsTestResourcesPath + "classes.ts", FileMetric.complexity, 0);
+        it("should not count any class declaration", () => {
+            testFileMetric(tsTestResourcesPath + "classes.ts", FileMetric.complexity, 0);
         });
 
-        it("should count case but no default statements correctly", async () => {
-            await testFileMetric(
-                tsTestResourcesPath + "case-statements.ts",
-                FileMetric.complexity,
-                3
-            );
+        it("should count case but no default statements correctly", () => {
+            testFileMetric(tsTestResourcesPath + "case-statements.ts", FileMetric.complexity, 3);
         });
 
-        it("should count try-catch-finally properly by only counting the catch-block", async () => {
-            await testFileMetric(
+        it("should count try-catch-finally properly by only counting the catch-block", () => {
+            testFileMetric(
                 tsTestResourcesPath + "throw-try-catch-finally.ts",
                 FileMetric.complexity,
                 1
             );
         });
 
-        it("should count loops properly", async () => {
-            await testFileMetric(tsTestResourcesPath + "loops.ts", FileMetric.complexity, 3);
+        it("should count loops properly", () => {
+            testFileMetric(tsTestResourcesPath + "loops.ts", FileMetric.complexity, 3);
         });
     });
 
     describe("parses TypeScript classes metric", () => {
-        it("should count class declarations", async () => {
-            await testFileMetric(tsTestResourcesPath + "classes.ts", FileMetric.classes, 3);
+        it("should count class declarations", () => {
+            testFileMetric(tsTestResourcesPath + "classes.ts", FileMetric.classes, 3);
         });
     });
 
     describe("parses TypeScript functions metric", () => {
-        it("should count functions and methods properly", async () => {
-            await testFileMetric(
+        it("should count functions and methods properly", () => {
+            testFileMetric(
                 tsTestResourcesPath + "functions-and-methods.ts",
                 FileMetric.functions,
                 9
@@ -71,20 +72,20 @@ describe("TypeScript metrics tests", () => {
     });
 
     describe("parses TypeScript comment lines metric", () => {
-        it("should count properly, also counting file header, class description and doc block tag comment lines", async () => {
-            await testFileMetric(tsTestResourcesPath + "comments.ts", FileMetric.commentLines, 14);
+        it("should count properly, also counting file header, class description and doc block tag comment lines", () => {
+            testFileMetric(tsTestResourcesPath + "comments.ts", FileMetric.commentLines, 14);
         });
 
-        it("should count properly, also in the presence of multiple block comments in the same line", async () => {
-            await testFileMetric(
+        it("should count properly, also in the presence of multiple block comments in the same line", () => {
+            testFileMetric(
                 tsTestResourcesPath + "same-line-comment.ts",
                 FileMetric.commentLines,
                 4
             );
         });
 
-        it("should count properly, also counting multiline block comments starting in the same line as another comment", async () => {
-            await testFileMetric(
+        it("should count properly, also counting multiline block comments starting in the same line as another comment", () => {
+            testFileMetric(
                 tsTestResourcesPath + "consecutive-comments.ts",
                 FileMetric.commentLines,
                 6
@@ -93,70 +94,62 @@ describe("TypeScript metrics tests", () => {
     });
 
     describe("parses TypeScript lines of code metric", () => {
-        it("should count number of lines correctly for a non-empty file with empty last line", async () => {
-            await testFileMetric(
-                tsTestResourcesPath + "ts-example-code.ts",
-                FileMetric.linesOfCode,
-                416
-            );
+        it("should count number of lines correctly for a non-empty file with empty last line", () => {
+            testFileMetric(tsTestResourcesPath + "ts-example-code.ts", FileMetric.linesOfCode, 416);
         });
 
-        it("should count number of lines correctly for a non-empty file with non-empty last line", async () => {
-            await testFileMetric(
+        it("should count number of lines correctly for a non-empty file with non-empty last line", () => {
+            testFileMetric(
                 tsTestResourcesPath + "non-empty-last-line.ts",
                 FileMetric.linesOfCode,
                 415
             );
         });
 
-        it("should count number of lines correctly for an empty file", async () => {
-            await testFileMetric(tsTestResourcesPath + "empty.ts", FileMetric.linesOfCode, 1);
+        it("should count number of lines correctly for an empty file", () => {
+            testFileMetric(tsTestResourcesPath + "empty.ts", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with one non-empty line", async () => {
-            await testFileMetric(tsTestResourcesPath + "one-line.ts", FileMetric.linesOfCode, 1);
+        it("should count number of lines correctly for an file with one non-empty line", () => {
+            testFileMetric(tsTestResourcesPath + "one-line.ts", FileMetric.linesOfCode, 1);
         });
 
-        it("should count number of lines correctly for an file with just a line break", async () => {
-            await testFileMetric(tsTestResourcesPath + "line-break.ts", FileMetric.linesOfCode, 2);
+        it("should count number of lines correctly for an file with just a line break", () => {
+            testFileMetric(tsTestResourcesPath + "line-break.ts", FileMetric.linesOfCode, 2);
         });
     });
 
     describe("parses TypeScript real lines of code metric", () => {
-        it("should count correctly for a non-empty file, ignoring comments and empty lines", async () => {
-            await testFileMetric(
+        it("should count correctly for a non-empty file, ignoring comments and empty lines", () => {
+            testFileMetric(
                 tsTestResourcesPath + "real-lines-of-code.ts",
                 FileMetric.realLinesOfCode,
                 7
             );
         });
 
-        it("should count correctly for an empty file", async () => {
-            await testFileMetric(tsTestResourcesPath + "empty.ts", FileMetric.realLinesOfCode, 0);
+        it("should count correctly for an empty file", () => {
+            testFileMetric(tsTestResourcesPath + "empty.ts", FileMetric.realLinesOfCode, 0);
         });
 
-        it("should count correctly for a file with a single comment", async () => {
-            await testFileMetric(
+        it("should count correctly for a file with a single comment", () => {
+            testFileMetric(
                 tsTestResourcesPath + "single-comment.ts",
                 FileMetric.realLinesOfCode,
                 0
             );
         });
 
-        it("should count correctly if there is a comment in the same line as actual code", async () => {
-            await testFileMetric(
+        it("should count correctly if there is a comment in the same line as actual code", () => {
+            testFileMetric(
                 tsTestResourcesPath + "same-line-comment.ts",
                 FileMetric.realLinesOfCode,
                 3
             );
         });
 
-        it("should count weirdly formatted lines of code correctly", async () => {
-            await testFileMetric(
-                tsTestResourcesPath + "weird-lines.ts",
-                FileMetric.realLinesOfCode,
-                32
-            );
+        it("should count weirdly formatted lines of code correctly", () => {
+            testFileMetric(tsTestResourcesPath + "weird-lines.ts", FileMetric.realLinesOfCode, 32);
         });
     });
 });

--- a/test/parser/TypeScriptMetrics.test.ts
+++ b/test/parser/TypeScriptMetrics.test.ts
@@ -1,4 +1,4 @@
-import { expectFileMetric, parseAllFileMetrics, testFileMetric } from "./TestHelper";
+import { expectFileMetric, parseAllFileMetrics } from "./TestHelper";
 import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 
 describe("TypeScript metrics tests", () => {

--- a/test/parser/UnknownFiles.test.ts
+++ b/test/parser/UnknownFiles.test.ts
@@ -1,27 +1,39 @@
-import { getFileMetrics } from "./TestHelper";
+import {
+    expectFileMetric,
+    getFileMetrics,
+    getParserConfiguration,
+    parseAllFileMetrics,
+} from "./TestHelper";
 import fs from "fs";
+import { MetricResult } from "../../src/parser/metrics/Metric";
+import { GenericParser } from "../../src/parser/GenericParser";
 
 describe("Test for handling files with unknown or no file extension", () => {
     const unknownTestResourcesPath = "./resources/unknown/";
 
+    let results;
+
+    const testFileMetric = (inputPath, metric, expected) =>
+        expectFileMetric(results, inputPath, metric, expected);
+
+    beforeAll(async () => {
+        const realInputPath = fs.realpathSync(unknownTestResourcesPath);
+        const parser = new GenericParser(getParserConfiguration(realInputPath));
+        results = await parser.calculateMetrics();
+    });
+
     describe("Include files with unknown or no file extension", () => {
         it("should list files with unknown file extension", async () => {
-            const results = await getFileMetrics(unknownTestResourcesPath);
-
             const filePath = fs.realpathSync(unknownTestResourcesPath + "example.unknownExtension");
             expect(results.unknownFiles.includes(filePath)).toBe(true);
         });
 
         it("should list files with no file extension", async () => {
-            const results = await getFileMetrics(unknownTestResourcesPath);
-
             const filePath = fs.realpathSync(unknownTestResourcesPath + "ExampleWithoutExtension");
             expect(results.unknownFiles.includes(filePath)).toBe(true);
         });
 
         it("should still list files with known extension", async () => {
-            const results = await getFileMetrics(unknownTestResourcesPath);
-
             const filePath = fs.realpathSync(unknownTestResourcesPath + "known.java");
             expect(results.fileMetrics.has(filePath)).toBe(true);
         });

--- a/test/parser/UnknownFiles.test.ts
+++ b/test/parser/UnknownFiles.test.ts
@@ -1,20 +1,11 @@
-import {
-    expectFileMetric,
-    getFileMetrics,
-    getParserConfiguration,
-    parseAllFileMetrics,
-} from "./TestHelper";
+import { expectFileMetric, getParserConfiguration } from "./TestHelper";
 import fs from "fs";
-import { MetricResult } from "../../src/parser/metrics/Metric";
 import { GenericParser } from "../../src/parser/GenericParser";
 
 describe("Test for handling files with unknown or no file extension", () => {
     const unknownTestResourcesPath = "./resources/unknown/";
 
     let results;
-
-    const testFileMetric = (inputPath, metric, expected) =>
-        expectFileMetric(results, inputPath, metric, expected);
 
     beforeAll(async () => {
         const realInputPath = fs.realpathSync(unknownTestResourcesPath);


### PR DESCRIPTION
Should reduce the probability of the race condition ~~and improve the performance of the test suites.~~
Also helped to identify a bug that only occurs when more than one source code file is parsed in one run: #90 

Is based on #89, so do not merge this until #89 has been merged.

Resolves #76 