### PR TITLE
Add support and tests for records and compact constructor #70

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,11 @@ Counts expressions that branch the control flow (if-statements, loops, catch-blo
 -   function declarations (including lambda expressions)
 -   binary logical operations (like AND and OR)
 
-Note: In Java, the default label in a switch statement is counted for complexity metric.
 **functions**<br>
 The number of function definitions inside a file. Includes all kinds of functions, like constructors, lambda functions, member functions, etc.
 
 **classes**<br>
-The number of class definitions inside a file, also counting for enums and interfaces.
+The number of class definitions inside a file, also counting for enums, interfaces, structs and records.
 
 **lines_of_code**<br>
 The total number of lines of a file, including empty lines, comments, etc.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Counts expressions that branch the control flow (if-statements, loops, catch-blo
 -   function declarations (including lambda expressions)
 -   binary logical operations (like AND and OR)
 
+Note: In Java, the default label in a switch statement is counted for complexity metric.
 **functions**<br>
 The number of function definitions inside a file. Includes all kinds of functions, like constructors, lambda functions, member functions, etc.
 

--- a/resources/c-sharp/records.cs
+++ b/resources/c-sharp/records.cs
@@ -11,3 +11,4 @@ public record struct Circle
     public double Y { get; init; }
 
 }
+public record class Ocean(string Address);

--- a/resources/c-sharp/records.cs
+++ b/resources/c-sharp/records.cs
@@ -1,0 +1,13 @@
+public record House(string Address, string City);
+public record Person
+{
+    public required string FirstName { get; init; }
+    public required string LastName { get; init; }
+};
+public readonly record struct Point(double X, double Y, double Z);
+public record struct Circle
+{
+    public double X { get; init; }
+    public double Y { get; init; }
+
+}

--- a/resources/java/classes/Person.java
+++ b/resources/java/classes/Person.java
@@ -1,13 +1,15 @@
+import java.util.Objects;
+
 public record Person(String name, String address) {
     public Person(String name) {
         this(name, "Unknown");
     }
 }
-public record Mensch (String name, String address) {
-    public Person {
+record Human (String name, String address) {
+    public Human {
         Objects.requireNonNull(name);
         Objects.requireNonNull(address);
     }
 }
-public record House(String address) {
+record House(String address) {
 }

--- a/resources/java/classes/Records.java
+++ b/resources/java/classes/Records.java
@@ -1,0 +1,13 @@
+public record Person(String name, String address) {
+    public Person(String name) {
+        this(name, "Unknown");
+    }
+}
+public record Mensch (String name, String address) {
+    public Person {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(address);
+    }
+}
+public record House(String address) {
+}

--- a/resources/java/complexity/SwitchStatement.java
+++ b/resources/java/complexity/SwitchStatement.java
@@ -4,8 +4,6 @@ public class SwitchStatementExample {
 
         switch (dayOfWeek) {
             case 1:
-                System.out.println("It's Sunday!");
-                break;
             case 2:
                 System.out.println("It's Monday!");
                 break;
@@ -27,20 +25,6 @@ public class SwitchStatementExample {
             default:
                 System.out.println("Invalid day of the week!");
         }
-        int number = 15;
 
-        switch (true) {
-            case (number > 0 && number < 10):
-                System.out.println("The number is between 1 and 9");
-                break;
-            case (number >= 10 || number < 20):
-                System.out.println("The number is between 10 and 19");
-                break;
-            case (number >= 20):
-                System.out.println("The number is 20 or greater");
-                break;
-            default:
-                System.out.println("The number is either negative or zero");
-        }
     }
 }

--- a/resources/java/complexity/WhileAndForLoop.java
+++ b/resources/java/complexity/WhileAndForLoop.java
@@ -16,9 +16,9 @@ class Loop {
             System.out.println("Iteration " + (counter + 1));
             counter++;
         }
+        int userInput=0;
         do {
             System.out.print("Enter a number (0 to exit): ");
-            userInput = scanner.nextInt();
 
             // Your code inside the loop goes here
             System.out.println("You entered: " + userInput);

--- a/resources/java/functions/InterfaceFunction.java
+++ b/resources/java/functions/InterfaceFunction.java
@@ -6,3 +6,4 @@ public interface MyInterface {
     default void defaultMethod() {
         System.out.println("Default implementation in MyInterface");
     }
+}

--- a/resources/java/functions/LambdaExpression.java
+++ b/resources/java/functions/LambdaExpression.java
@@ -18,4 +18,8 @@ public class SampleFunctions {
     interface MyFunctionalInterface {
         int performOperation(int value);
     }
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 442e08f (test: add deleted lambda test (Java) #70)

--- a/resources/java/functions/LambdaExpression.java
+++ b/resources/java/functions/LambdaExpression.java
@@ -4,22 +4,21 @@ public class SampleFunctions {
         int result = operation.performOperation(value);
         System.out.println("Operation Result: " + result);
     }
+
     public static int square(int num) {
         Function<Integer, Integer> squareFunction = n -> n * n;
         return squareFunction.apply(num);
     }
+
     public static void main(String[] args) {
         executeOperation(4, (x) -> x * 2); // Lambda expression for doubling the value
 
         int squaredResult = square(3);
         System.out.println("Square Result: " + squaredResult);
     }
+
     @FunctionalInterface
     interface MyFunctionalInterface {
         int performOperation(int value);
     }
-<<<<<<< HEAD
 }
-=======
-}
->>>>>>> 442e08f (test: add deleted lambda test (Java) #70)

--- a/resources/java/functions/RecordMethods.java
+++ b/resources/java/functions/RecordMethods.java
@@ -1,0 +1,15 @@
+public record House (String name, String address) {
+    public House(String name) {
+        this(name, "Unknown");
+    }
+}
+public record Person(String name, String address) {
+    public Person {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(address);
+    }
+
+    public static Person unnamed(String address) {
+        return new Person("Unnamed", address);
+    }
+}

--- a/resources/java/functions/RecordMethods.java
+++ b/resources/java/functions/RecordMethods.java
@@ -1,5 +1,5 @@
-public record House (String name, String address) {
-    public House(String name) {
+record House (String name, String address) {
+    House(String name) {
         this(name, "Unknown");
     }
 }

--- a/resources/java/functions/StaticFuntions.java
+++ b/resources/java/functions/StaticFuntions.java
@@ -11,7 +11,8 @@ public class ExampleClass {
     public void incrementInstanceVariable() {
         instanceVariable++;
     }
-    public void returnMessage() {
+    public String returnMessage() {
+        return this.message;
     }
     public static void main(String[] args) {
         ExampleClass obj1 = new ExampleClass(5);

--- a/resources/java/functions/StaticFuntions.java
+++ b/resources/java/functions/StaticFuntions.java
@@ -5,14 +5,13 @@ public class ExampleClass {
     public static void incrementStaticVariable() {
         staticVariable++;
     }
-    public static int returnStaticMessage() {
+    public static String returnStaticMessage() {
         return "Hello";
     }
     public void incrementInstanceVariable() {
         instanceVariable++;
     }
     public void returnMessage() {
-        return this.message;
     }
     public static void main(String[] args) {
         ExampleClass obj1 = new ExampleClass(5);

--- a/resources/java/lines_of_code/MultilineLineOfCode.java
+++ b/resources/java/lines_of_code/MultilineLineOfCode.java
@@ -9,7 +9,7 @@ class MultiLine {
             + "string using escape characters.";
 
 
-    String multiLineString = """
+    String multiLineString2 = """
             This is a multi-line
             string using text blocks.
             """;

--- a/resources/java/real_lines_of_code/InlineComment.java
+++ b/resources/java/real_lines_of_code/InlineComment.java
@@ -1,4 +1,4 @@
 class Hello {
     String greetingMessage; // the message to be printed
-    int i = 1: // i is initialized to 1
+    int i = 1; // i is initialized to 1
 }

--- a/resources/java/real_lines_of_code/MultilineRealLineOfCode.java
+++ b/resources/java/real_lines_of_code/MultilineRealLineOfCode.java
@@ -5,7 +5,7 @@ class MultiLine {
     String multiLineString = "This is a multi-line \n"
             + "string using escape characters.";
 
-    String multiLineString = """
+    String multiLineString2 = """
             This is a multi-line
             string using text blocks.
             """;

--- a/src/parser/config/nodeTypesConfig.json
+++ b/src/parser/config/nodeTypesConfig.json
@@ -106,7 +106,7 @@
     },
     {
         "expression": "record_declaration",
-        "metrics": [],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
         "languages": ["cs", "java"]
@@ -5872,7 +5872,7 @@
     },
     {
         "expression": "record_struct_declaration",
-        "metrics": [],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
         "languages": ["cs"]
@@ -6117,7 +6117,7 @@
     },
     {
         "expression": "compact_constructor_declaration",
-        "metrics": [],
+        "metrics": ["functions", "complexity"],
         "type": "statement",
         "category": "",
         "languages": ["java"]

--- a/test/parser/CSharpMetric.test.ts
+++ b/test/parser/CSharpMetric.test.ts
@@ -67,6 +67,9 @@ describe("C# metric tests", () => {
         it("should count class declarations", async () => {
             await testFileMetric(csharpTestResourcesPath + "classes.cs", FileMetric.classes, 6);
         });
+        it("should count record declarations", async () => {
+            await testFileMetric(csharpTestResourcesPath + "records.cs", FileMetric.classes, 4);
+        });
     });
 
     describe("parses C# functions metric", () => {

--- a/test/parser/CSharpMetric.test.ts
+++ b/test/parser/CSharpMetric.test.ts
@@ -68,7 +68,7 @@ describe("C# metric tests", () => {
             await testFileMetric(csharpTestResourcesPath + "classes.cs", FileMetric.classes, 6);
         });
         it("should count record declarations", async () => {
-            await testFileMetric(csharpTestResourcesPath + "records.cs", FileMetric.classes, 4);
+            await testFileMetric(csharpTestResourcesPath + "records.cs", FileMetric.classes, 5);
         });
     });
 

--- a/test/parser/JavaMetrics.test.ts
+++ b/test/parser/JavaMetrics.test.ts
@@ -50,6 +50,7 @@ describe("Java metrics tests.", () => {
                 0
             );
         });
+
         it("should count all record declarations as classes", async () => {
             await testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.classes + "/Person.java",
@@ -223,13 +224,14 @@ describe("Java metrics tests.", () => {
             );
         });
 
-        it("should count one method declaration, the number of switch-case-statements and the contained logical operators correctly", async () => {
+        it("should count one method declaration, all logical operators and all case- and default-labels", async () => {
             await testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/SwitchStatement.java",
                 FileMetric.complexity,
                 9
             );
         });
+
         it("should count all method declarations, if-statements and catch blocks, but not throw and finally blocks.", async () => {
             await testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/TryCatchFinally.java",
@@ -237,6 +239,7 @@ describe("Java metrics tests.", () => {
                 8
             );
         });
+
         it("should count all method declarations and ternary operations", async () => {
             await testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/TernaryOperation.java",
@@ -244,6 +247,7 @@ describe("Java metrics tests.", () => {
                 2
             );
         });
+
         it("should count all method declarations (incl. lambda expressions) and for-loops, but not method references.", async () => {
             await testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/DifferentFunctions.java",
@@ -251,6 +255,7 @@ describe("Java metrics tests.", () => {
                 5
             );
         });
+
         it("should count logical operators and function declarations.", async () => {
             await testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/LogicalOperator.java",

--- a/test/parser/JavaMetrics.test.ts
+++ b/test/parser/JavaMetrics.test.ts
@@ -50,6 +50,13 @@ describe("Java metrics tests.", () => {
                 0
             );
         });
+        it("should count all records.cs as classes", async () => {
+            await testFileMetric(
+                javaTestResourcesPath + "/" + FileMetric.classes + "/Records.java",
+                FileMetric.classes,
+                3
+            );
+        });
     });
 
     describe("parses lines of code metric", () => {
@@ -181,11 +188,20 @@ describe("Java metrics tests.", () => {
                 3
             );
         });
+
         it("should count all function declarations and lambda expression", async () => {
             await testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.functions + "/LambdaExpression.java",
                 FileMetric.functions,
                 6
+            );
+        });
+
+        it("should count all record-constructors", async () => {
+            await testFileMetric(
+                javaTestResourcesPath + "/" + FileMetric.functions + "/RecordMethods.java",
+                FileMetric.functions,
+                3
             );
         });
     });

--- a/test/parser/JavaMetrics.test.ts
+++ b/test/parser/JavaMetrics.test.ts
@@ -50,9 +50,9 @@ describe("Java metrics tests.", () => {
                 0
             );
         });
-        it("should count all records.cs as classes", async () => {
+        it("should count all record declarations as classes", async () => {
             await testFileMetric(
-                javaTestResourcesPath + "/" + FileMetric.classes + "/Records.java",
+                javaTestResourcesPath + "/" + FileMetric.classes + "/Person.java",
                 FileMetric.classes,
                 3
             );
@@ -227,7 +227,7 @@ describe("Java metrics tests.", () => {
             await testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/SwitchStatement.java",
                 FileMetric.complexity,
-                13
+                8
             );
         });
         it("should count all method declarations, if-statements and catch blocks, but not throw and finally blocks.", async () => {

--- a/test/parser/JavaMetrics.test.ts
+++ b/test/parser/JavaMetrics.test.ts
@@ -223,11 +223,11 @@ describe("Java metrics tests.", () => {
             );
         });
 
-        it.skip("should count one method declaration, the number of switch-case-statements and the contained logical operators correctly", async () => {
+        it("should count one method declaration, the number of switch-case-statements and the contained logical operators correctly", async () => {
             await testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/SwitchStatement.java",
                 FileMetric.complexity,
-                8
+                9
             );
         });
         it("should count all method declarations, if-statements and catch blocks, but not throw and finally blocks.", async () => {

--- a/test/parser/JavaMetrics.test.ts
+++ b/test/parser/JavaMetrics.test.ts
@@ -224,7 +224,7 @@ describe("Java metrics tests.", () => {
             );
         });
 
-        it("should count one method declaration, all logical operators and all case- and default-labels", async () => {
+        it("should count one method declaration and all case- and default-labels", async () => {
             await testFileMetric(
                 javaTestResourcesPath + "/" + FileMetric.complexity + "/SwitchStatement.java",
                 FileMetric.complexity,


### PR DESCRIPTION
Counts records in Java and C# as classes, as they are a special form of class with more build-in features.

I removed the skip label for the switch statement test. We decided that default label should also be counted for complexity metric temporarily. This will also be mentioned in README.md.  
Closes #70 