### PR TITLE
Added support for .tsx-files and Flow-annotated JavaScript-files.

### DIFF
--- a/src/commands/import-grammars/ImportNodeTypes.ts
+++ b/src/commands/import-grammars/ImportNodeTypes.ts
@@ -20,6 +20,7 @@ export const languageAbbreviationToNodeTypeFiles = new Map([
     ["kt", "./node_modules/tree-sitter-kotlin/src/node-types.json"],
     ["php", "./node_modules/tree-sitter-php/src/node-types.json"],
     ["ts", "./node_modules/tree-sitter-typescript/typescript/src/node-types.json"],
+    ["tsx", "./node_modules/tree-sitter-typescript/tsx/src/node-types.json"],
     ["py", "./node_modules/tree-sitter-python/src/node-types.json"],
     ["cpp", "./node_modules/tree-sitter-cpp/src/node-types.json"],
 ]);

--- a/src/parser/config/nodeTypesConfig.json
+++ b/src/parser/config/nodeTypesConfig.json
@@ -1,1315 +1,829 @@
 [
     {
         "expression": "class_declaration",
-        "metrics": [
-            "classes"
-        ],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "js",
-            "kt",
-            "php",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "js", "kt", "php", "ts", "tsx"]
     },
     {
         "expression": "constructor_declaration",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java"
-        ]
+        "languages": ["cs", "java"]
     },
     {
         "expression": "conversion_operator_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "delegate_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "destructor_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "enum_declaration",
-        "metrics": [
-            "classes"
-        ],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "ts",
-            "php",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "ts", "php", "tsx"]
     },
     {
         "expression": "event_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "event_field_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "field_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "cpp"
-        ]
+        "languages": ["cs", "go", "java", "cpp"]
     },
     {
         "expression": "indexer_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "interface_declaration",
-        "metrics": [
-            "classes"
-        ],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "php",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "php", "ts", "tsx"]
     },
     {
         "expression": "method_declaration",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "php"
-        ]
+        "languages": ["cs", "go", "java", "php"]
     },
     {
         "expression": "namespace_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "operator_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "property_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "kt",
-            "php"
-        ]
+        "languages": ["cs", "kt", "php"]
     },
     {
         "expression": "record_declaration",
-        "metrics": [
-            "classes"
-        ],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java"
-        ]
+        "languages": ["cs", "java"]
     },
     {
         "expression": "struct_declaration",
-        "metrics": [
-            "classes"
-        ],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "using_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "anonymous_method_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "anonymous_object_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "array_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "php"
-        ]
+        "languages": ["cs", "java", "php"]
     },
     {
         "expression": "as_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "kt",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["cs", "kt", "ts", "tsx"]
     },
     {
         "expression": "assignment_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "js", "php", "ts", "cpp", "tsx"]
     },
     {
         "expression": "await_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["cs", "js", "ts", "tsx"]
     },
     {
         "expression": "base_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "binary_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"]
     },
     {
         "expression": "boolean_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "kt"
-        ]
+        "languages": ["cs", "kt"]
     },
     {
         "expression": "cast_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "php",
-            "cpp"
-        ]
+        "languages": ["cs", "java", "php", "cpp"]
     },
     {
         "expression": "character_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "kt"
-        ]
+        "languages": ["cs", "java", "kt"]
     },
     {
         "expression": "checked_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "conditional_access_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "conditional_expression",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "php",
-            "py",
-            "cpp"
-        ]
+        "languages": ["cs", "php", "py", "cpp"]
     },
     {
         "expression": "default_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "element_access_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "element_binding_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "generic_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "global",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "kt",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "java", "js", "kt", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "implicit_array_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "implicit_object_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "implicit_stack_alloc_array_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "initializer_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "integer_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "kt"
-        ]
+        "languages": ["cs", "kt"]
     },
     {
         "expression": "interpolated_string_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "invocation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "is_expression",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "is_pattern_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "lambda_expression",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "cpp"
-        ]
+        "languages": ["cs", "java", "cpp"]
     },
     {
         "expression": "make_ref_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "member_access_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "php"
-        ]
+        "languages": ["cs", "php"]
     },
     {
         "expression": "null_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java"
-        ]
+        "languages": ["cs", "java"]
     },
     {
         "expression": "object_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "php"
-        ]
+        "languages": ["cs", "java", "php"]
     },
     {
         "expression": "parenthesized_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "kt",
-            "php",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "java", "js", "kt", "php", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "postfix_unary_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "prefix_unary_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "query_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "range_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "kt"
-        ]
+        "languages": ["cs", "kt"]
     },
     {
         "expression": "real_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "kt"
-        ]
+        "languages": ["cs", "kt"]
     },
     {
         "expression": "ref_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "ref_type_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "ref_value_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "size_of_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "stack_alloc_array_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "string_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "cpp",
-            "kt"
-        ]
+        "languages": ["cs", "java", "cpp", "kt"]
     },
     {
         "expression": "switch_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java"
-        ]
+        "languages": ["cs", "java"]
     },
     {
         "expression": "this_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "kt"
-        ]
+        "languages": ["cs", "kt"]
     },
     {
         "expression": "throw_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "php"
-        ]
+        "languages": ["cs", "php"]
     },
     {
         "expression": "tuple_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "type_of_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "verbatim_string_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "with_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "py"
-        ]
+        "languages": ["cs", "go", "java", "py"]
     },
     {
         "expression": "break_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "checked_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "continue_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "do_statement",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "js", "php", "ts", "cpp", "tsx"]
     },
     {
         "expression": "empty_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "js",
-            "php",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "js", "php", "ts", "tsx"]
     },
     {
         "expression": "expression_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "py",
-            "cpp",
-            "go",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "js", "php", "ts", "py", "cpp", "go", "tsx"]
     },
     {
         "expression": "fixed_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "for_each_statement",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "for_statement",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "kt",
-            "php",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "java", "js", "kt", "php", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "goto_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "php",
-            "cpp"
-        ]
+        "languages": ["cs", "go", "php", "cpp"]
     },
     {
         "expression": "if_statement",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "labeled_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "java", "js", "ts", "cpp", "tsx"]
     },
     {
         "expression": "local_declaration_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "local_function_statement",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "lock_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "return_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "switch_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "js", "php", "ts", "cpp", "tsx"]
     },
     {
         "expression": "throw_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "js",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "js", "ts", "cpp", "tsx"]
     },
     {
         "expression": "try_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "js", "php", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "unsafe_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "using_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "while_statement",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "js",
-            "kt",
-            "php",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "js", "kt", "php", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "yield_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java"
-        ]
+        "languages": ["cs", "java"]
     },
     {
         "expression": "alias_qualified_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "array_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "java", "ts", "tsx"]
     },
     {
         "expression": "function_pointer_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "implicit_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "nullable_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "kt"
-        ]
+        "languages": ["cs", "kt"]
     },
     {
         "expression": "pointer_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go"
-        ]
+        "languages": ["cs", "go"]
     },
     {
         "expression": "predefined_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["cs", "ts", "tsx"]
     },
     {
         "expression": "qualified_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "php"
-        ]
+        "languages": ["cs", "php"]
     },
     {
         "expression": "tuple_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["cs", "ts", "tsx"]
     },
     {
         "expression": "accessor_declaration",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "accessor_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "argument",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "php"
-        ]
+        "languages": ["cs", "php"]
     },
     {
         "expression": "argument_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "py",
-            "cpp"
-        ]
+        "languages": ["cs", "go", "java", "py", "cpp"]
     },
     {
         "expression": "array_rank_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "arrow_expression_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "assignment_operator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "attribute",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "py",
-            "cpp",
-            "php"
-        ]
+        "languages": ["cs", "py", "cpp", "php"]
     },
     {
         "expression": "attribute_argument",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "attribute_argument_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "attribute_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "php"
-        ]
+        "languages": ["cs", "php"]
     },
     {
         "expression": "attribute_target_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "base_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "binary_expression_!=",
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "!="
     },
     {
@@ -1317,16 +831,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "%"
     },
     {
@@ -1334,35 +839,15 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "&"
     },
     {
         "expression": "binary_expression_&&",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "&&"
     },
     {
@@ -1370,16 +855,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "*"
     },
     {
@@ -1387,16 +863,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "+"
     },
     {
@@ -1404,16 +871,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "-"
     },
     {
@@ -1421,16 +879,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "/"
     },
     {
@@ -1438,16 +887,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "<"
     },
     {
@@ -1455,16 +895,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "<<"
     },
     {
@@ -1472,16 +903,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "<="
     },
     {
@@ -1489,16 +911,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "=="
     },
     {
@@ -1506,16 +919,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": ">"
     },
     {
@@ -1523,16 +927,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": ">="
     },
     {
@@ -1540,32 +935,15 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": ">>"
     },
     {
         "expression": "binary_expression_??",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "js",
-            "ts",
-            "php",
-            "tsx"
-        ],
+        "languages": ["cs", "js", "ts", "php", "tsx"],
         "operator": "??"
     },
     {
@@ -1573,16 +951,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "^"
     },
     {
@@ -1590,35 +959,15 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "|"
     },
     {
         "expression": "binary_expression_||",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cs",
-            "go",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx"],
         "operator": "||"
     },
     {
@@ -1626,2009 +975,1430 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "bracketed_parameter_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "case_pattern_switch_label",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "case_label",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "case_switch_label",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "case_label",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "catch_clause",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "js", "php", "ts", "cpp", "tsx"]
     },
     {
         "expression": "catch_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "catch_filter_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "compilation_unit",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "constant_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "constructor_constraint",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "constructor_initializer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "declaration_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "declaration_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "php",
-            "cpp"
-        ]
+        "languages": ["cs", "php", "cpp"]
     },
     {
         "expression": "declaration_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "default_switch_label",
         "metrics": [],
         "type": "statement",
         "category": "default_label",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "enum_member_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "enum_member_declaration_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "equals_value_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "explicit_interface_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "extern_alias_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "finally_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "js",
-            "php",
-            "ts",
-            "py",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "js", "php", "ts", "py", "tsx"]
     },
     {
         "expression": "from_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "function_pointer_calling_convention",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "function_pointer_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "function_pointer_unmanaged_calling_convention",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "function_pointer_unmanaged_calling_convention_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "global_attribute_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "global_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "py"
-        ]
+        "languages": ["cs", "py"]
     },
     {
         "expression": "group_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "interpolated_string_text",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "interpolated_verbatim_string_text",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "interpolation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "py"
-        ]
+        "languages": ["cs", "py"]
     },
     {
         "expression": "interpolation_alignment_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "interpolation_format_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "join_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "join_into_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "label_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "let_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "member_binding_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "name_colon",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "name_equals",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "negated_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "order_by_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "kt"
-        ]
+        "languages": ["cs", "kt"]
     },
     {
         "expression": "parameter_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "cpp"
-        ]
+        "languages": ["cs", "go", "cpp"]
     },
     {
         "expression": "parameter_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "kt"
-        ]
+        "languages": ["cs", "kt"]
     },
     {
         "expression": "parenthesized_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "parenthesized_variable_designation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "positional_pattern_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "primary_constructor_base_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "property_pattern_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "query_continuation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "recursive_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "relational_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "select_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "simple_assignment_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "subpattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "switch_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["cs", "js", "ts", "tsx"]
     },
     {
         "expression": "switch_expression_arm",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "switch_section",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "tuple_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "tuple_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "py"
-        ]
+        "languages": ["cs", "py"]
     },
     {
         "expression": "type_argument_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "type_constraint",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "kt"
-        ]
+        "languages": ["cs", "kt"]
     },
     {
         "expression": "type_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "kt",
-            "ts",
-            "py",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "kt", "ts", "py", "tsx"]
     },
     {
         "expression": "type_parameter_constraint",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "type_parameter_constraints_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "type_parameter_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go"
-        ]
+        "languages": ["cs", "go"]
     },
     {
         "expression": "type_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java"
-        ]
+        "languages": ["cs", "java"]
     },
     {
         "expression": "var_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "variable_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "js",
-            "kt",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["cs", "js", "kt", "ts", "tsx"]
     },
     {
         "expression": "variable_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "java",
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["cs", "java", "js", "ts", "tsx"]
     },
     {
         "expression": "when_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "where_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "with_initializer_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": ";",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "await",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "class",
-        "metrics": [
-            "classes"
-        ],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "comment",
-        "metrics": [
-            "comment_lines",
-            "real_lines_of_code"
-        ],
+        "metrics": ["comment_lines", "real_lines_of_code"],
         "type": "statement",
         "category": "comment",
-        "languages": [
-            "cs",
-            "go",
-            "js",
-            "php",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "js", "php", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "discard",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "escape_sequence",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs",
-            "go",
-            "js",
-            "ts",
-            "py",
-            "cpp",
-            "java",
-            "php",
-            "tsx"
-        ]
+        "languages": ["cs", "go", "js", "ts", "py", "cpp", "java", "php", "tsx"]
     },
     {
         "expression": "false",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "go",
-            "java",
-            "js",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["go", "java", "js", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "module",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "activated_for_languages": [
-            "py"
-        ],
-        "languages": [
-            "ts",
-            "py",
-            "tsx"
-        ]
+        "activated_for_languages": ["py"],
+        "languages": ["ts", "py", "tsx"]
     },
     {
         "expression": "set",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "this",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "java",
-            "js",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["java", "js", "ts", "cpp", "tsx"]
     },
     {
         "expression": "true",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "go",
-            "java",
-            "js",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["go", "java", "js", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "type",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "virtual",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "void_keyword",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "yield",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "call_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "js",
-            "kt",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["go", "js", "kt", "ts", "cpp", "tsx"]
     },
     {
         "expression": "composite_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "float_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "func_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "imaginary_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "index_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "int_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "interpreted_string_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "nil",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "raw_string_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "cpp"
-        ]
+        "languages": ["go", "cpp"]
     },
     {
         "expression": "rune_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "selector_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "slice_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "type_assertion_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "type_conversion_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "unary_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "java",
-            "js",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["go", "java", "js", "ts", "cpp", "tsx"]
     },
     {
         "expression": "_simple_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "assignment_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "dec_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "inc_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "send_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "short_var_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "_simple_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "java"
-        ]
+        "languages": ["go", "java"]
     },
     {
         "expression": "channel_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "function_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "kt",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["go", "kt", "ts", "tsx"]
     },
     {
         "expression": "interface_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "map_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "qualified_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "slice_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "struct_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "type_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "java",
-            "kt",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["go", "java", "kt", "ts", "cpp", "tsx"]
     },
     {
         "expression": "const_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "php"
-        ]
+        "languages": ["go", "php"]
     },
     {
         "expression": "defer_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "expression_switch_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "fallthrough_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "go_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "select_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "type_declaration",
-        "metrics": [
-            "classes"
-        ],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "type_switch_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "var_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "parenthesized_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "kt",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["go", "kt", "ts", "tsx"]
     },
     {
         "expression": "binary_expression_&^",
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "go"
-        ],
+        "languages": ["go"],
         "operator": "&^"
     },
     {
         "expression": "communication_case",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "case_label",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "const_spec",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "default_case",
         "metrics": [],
         "type": "statement",
         "category": "default_label",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "dot",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "expression_case",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "case_label",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "expression_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "py"
-        ]
+        "languages": ["go", "py"]
     },
     {
         "expression": "field_declaration_list",
-        "metrics": [
-            "classes"
-        ],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "cpp"
-        ]
+        "languages": ["go", "cpp"]
     },
     {
         "expression": "for_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "function_declaration",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "js",
-            "kt",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["go", "js", "kt", "ts", "tsx"]
     },
     {
         "expression": "implicit_length_array_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "import_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "java"
-        ]
+        "languages": ["go", "java"]
     },
     {
         "expression": "import_spec",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "import_spec_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "keyed_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "literal_value",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "method_spec",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "package_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "cpp"
-        ]
+        "languages": ["go", "cpp"]
     },
     {
         "expression": "range_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "receive_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "source_file",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "kt"
-        ]
+        "languages": ["go", "kt"]
     },
     {
         "expression": "type_alias",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "kt"
-        ]
+        "languages": ["go", "kt"]
     },
     {
         "expression": "type_case",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "case_label",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "type_spec",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "var_spec",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "variadic_argument",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "variadic_parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go",
-            "cpp"
-        ]
+        "languages": ["go", "cpp"]
     },
     {
         "expression": "blank_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "field_identifier",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "go",
-            "cpp"
-        ]
+        "languages": ["go", "cpp"]
     },
     {
         "expression": "import",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "package_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "php"
-        ]
+        "languages": ["java", "php"]
     },
     {
         "expression": "binary_integer_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "decimal_floating_point_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "decimal_integer_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "hex_floating_point_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "hex_integer_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "octal_integer_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "boolean_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "floating_point_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "generic_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "ts",
-            "go",
-            "py",
-            "tsx"
-        ]
+        "languages": ["java", "ts", "go", "py", "tsx"]
     },
     {
         "expression": "integral_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "scoped_type_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "void_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "_unannotated_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "annotated_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "js",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["java", "js", "ts", "cpp", "tsx"]
     },
     {
         "expression": "annotation_type_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "module_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "package_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "instanceof_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "primary_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "js",
-            "ts",
-            "py",
-            "tsx"
-        ]
+        "languages": ["java", "js", "ts", "py", "tsx"]
     },
     {
         "expression": "ternary_expression",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["java", "js", "ts", "tsx"]
     },
     {
         "expression": "update_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["java", "js", "php", "ts", "cpp", "tsx"]
     },
     {
         "expression": "array_access",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "class_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "field_access",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "method_invocation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "method_reference",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "assert_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "py"
-        ]
+        "languages": ["java", "py"]
     },
     {
         "expression": "enhanced_for_statement",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "local_variable_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "synchronized_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "try_with_resources_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "kt"
-        ]
+        "languages": ["java", "kt"]
     },
     {
         "expression": "annotation_argument_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "annotation_type_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "annotation_type_element_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "array_initializer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "asterisk",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "binary_expression_>>>",
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "java",
-            "js",
-            "ts",
-            "tsx"
-        ],
+        "languages": ["java", "js", "ts", "tsx"],
         "operator": ">>>"
     },
     {
@@ -3636,780 +2406,511 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "catch_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "class_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "js",
-            "kt",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["java", "js", "kt", "ts", "tsx"]
     },
     {
         "expression": "constant_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "constructor_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "dimensions",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "dimensions_expr",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "element_value_array_initializer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "element_value_pair",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "enum_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["java", "ts", "tsx"]
     },
     {
         "expression": "enum_body_declarations",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "enum_constant",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "explicit_constructor_invocation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "extends_interfaces",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "formal_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "formal_parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "js",
-            "php",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["java", "js", "php", "ts", "tsx"]
     },
     {
         "expression": "inferred_parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "interface_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["java", "ts", "tsx"]
     },
     {
         "expression": "marker_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "modifiers",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "kt"
-        ]
+        "languages": ["java", "kt"]
     },
     {
         "expression": "module_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "program",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "js",
-            "php",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["java", "js", "php", "ts", "tsx"]
     },
     {
         "expression": "receiver_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "requires_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "resource",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "resource_specification",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "scoped_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "spread_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "static_initializer",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "super_interfaces",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "superclass",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "switch_block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "php"
-        ]
+        "languages": ["java", "php"]
     },
     {
         "expression": "switch_label",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "case_label",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "throws",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "type_arguments",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "kt",
-            "ts",
-            "go",
-            "tsx"
-        ]
+        "languages": ["java", "kt", "ts", "go", "tsx"]
     },
     {
         "expression": "type_bound",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "type_parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "kt",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["java", "kt", "ts", "tsx"]
     },
     {
         "expression": "wildcard",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "float",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "php",
-            "py"
-        ]
+        "languages": ["php", "py"]
     },
     {
         "expression": "super",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "java",
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["java", "js", "ts", "tsx"]
     },
     {
         "expression": "generator_function_declaration",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "lexical_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "augmented_assignment_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "php",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "php", "ts", "tsx"]
     },
     {
         "expression": "jsx_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "jsx_self_closing_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "new_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "cpp", "tsx"]
     },
     {
         "expression": "yield_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "php",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "php", "ts", "tsx"]
     },
     {
         "expression": "pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "array_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "object_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "rest_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "array",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "arrow_function",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "php",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "php", "tsx"]
     },
     {
         "expression": "generator_function",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "member_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "meta_property",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "null",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["js", "php", "ts", "cpp", "tsx"]
     },
     {
         "expression": "number",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "object",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "regex",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "php",
-            "ts",
-            "py",
-            "tsx"
-        ]
+        "languages": ["js", "php", "ts", "py", "tsx"]
     },
     {
         "expression": "subscript_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "php",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["js", "php", "ts", "cpp", "tsx"]
     },
     {
         "expression": "template_string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "undefined",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "debugger_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "export_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "for_in_statement",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "import_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "py",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "py", "tsx"]
     },
     {
         "expression": "statement_block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "with_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "py",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "py", "tsx"]
     },
     {
         "expression": "arguments",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "php",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "php", "ts", "tsx"]
     },
     {
         "expression": "assignment_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "binary_expression_!==",
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "js",
-            "php",
-            "ts",
-            "tsx"
-        ],
+        "languages": ["js", "php", "ts", "tsx"],
         "operator": "!=="
     },
     {
@@ -4417,11 +2918,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ],
+        "languages": ["js", "ts", "tsx"],
         "operator": "**"
     },
     {
@@ -4429,12 +2926,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "js",
-            "php",
-            "ts",
-            "tsx"
-        ],
+        "languages": ["js", "php", "ts", "tsx"],
         "operator": "==="
     },
     {
@@ -4442,11 +2934,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ],
+        "languages": ["js", "ts", "tsx"],
         "operator": "in"
     },
     {
@@ -4454,12 +2942,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "js",
-            "php",
-            "ts",
-            "tsx"
-        ],
+        "languages": ["js", "php", "ts", "tsx"],
         "operator": "instanceof"
     },
     {
@@ -4467,1604 +2950,1148 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "computed_property_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "decorator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "py",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "py", "tsx"]
     },
     {
         "expression": "else_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "php",
-            "ts",
-            "py",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["js", "php", "ts", "py", "cpp", "tsx"]
     },
     {
         "expression": "export_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "export_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "import_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "import_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "jsx_attribute",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "jsx_closing_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "jsx_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "jsx_namespace_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "jsx_opening_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "method_definition",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "named_imports",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "namespace_import",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "nested_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "object_assignment_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "pair",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "php",
-            "ts",
-            "py",
-            "tsx"
-        ]
+        "languages": ["js", "php", "ts", "py", "tsx"]
     },
     {
         "expression": "pair_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "public_field_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "sequence_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "php",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "php", "ts", "tsx"]
     },
     {
         "expression": "spread_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "switch_case",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "case_label",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "switch_default",
         "metrics": [],
         "type": "statement",
         "category": "default_label",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "template_substitution",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "hash_bang_line",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "jsx_text",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "property_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "regex_flags",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "regex_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "shorthand_property_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "shorthand_property_identifier_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "statement_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "cpp",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "cpp", "tsx"]
     },
     {
         "expression": "additive_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "annotated_lambda",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "anonymous_function",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "anonymous_initializer",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "assignment",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt",
-            "py"
-        ]
+        "languages": ["kt", "py"]
     },
     {
         "expression": "call_suffix",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "callable_reference",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "catch_block",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "check_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "class_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "class_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "collection_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "companion_object",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "comparison_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "conjunction_expression",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "constructor_delegation_call",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "constructor_invocation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "control_structure_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "delegation_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "directly_assignable_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "disjunction_expression",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "do_while_statement",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "elvis_expression",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "enum_class_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "enum_entry",
-        "metrics": [
-            "classes"
-        ],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "equality_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "explicit_delegation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "file_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "finally_block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "function_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "function_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "function_type_parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "if_expression",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "import_alias",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["kt", "ts", "tsx"]
     },
     {
         "expression": "import_header",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "indexing_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "indexing_suffix",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "infix_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "inheritance_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "interpolated_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "interpolated_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "jump_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "lambda_literal",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "lambda_parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt",
-            "py"
-        ]
+        "languages": ["kt", "py"]
     },
     {
         "expression": "long_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "member_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "multiplicative_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "navigation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "navigation_suffix",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "object_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "object_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "package_header",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "parameter_modifiers",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "parameter_with_optional_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "parenthesized_user_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "platform_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "postfix_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "prefix_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "primary_constructor",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "property_delegate",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "range_test",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "secondary_constructor",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "setter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "shebang_line",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "simple_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "spread_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "statements",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "super_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "try_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "type_constraints",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "type_modifiers",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "type_parameter_modifiers",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "type_projection",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "type_projection_modifiers",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "type_test",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "unsigned_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "use_site_target",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "user_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "value_argument",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "value_arguments",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "variance_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "visibility_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt",
-            "php"
-        ]
+        "languages": ["kt", "php"]
     },
     {
         "expression": "when_condition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "when_entry",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "case_label",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "when_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "when_subject",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "bin_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "hex_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "label",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "property_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "reification_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "_primary_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "clone_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "exponentiation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "include_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "include_once_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "require_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "require_once_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "unary_op_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "boolean",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "heredoc",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "integer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php",
-            "py"
-        ]
+        "languages": ["php", "py"]
     },
     {
         "expression": "anonymous_function_creation_expression",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "class_constant_access_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "dynamic_variable_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "function_call_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "member_call_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "print_intrinsic",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "scoped_call_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "scoped_property_access_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "shell_command_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "variable_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "compound_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php",
-            "cpp"
-        ]
+        "languages": ["php", "cpp"]
     },
     {
         "expression": "declare_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "echo_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "foreach_statement",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "function_definition",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php",
-            "py",
-            "cpp"
-        ]
+        "languages": ["php", "py", "cpp"]
     },
     {
         "expression": "function_static_declaration",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "global_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "named_label_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "namespace_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php",
-            "cpp"
-        ]
+        "languages": ["php", "cpp"]
     },
     {
         "expression": "namespace_use_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "trait_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "unset_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "optional_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["php", "ts", "tsx"]
     },
     {
         "expression": "primitive_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php",
-            "cpp"
-        ]
+        "languages": ["php", "cpp"]
     },
     {
         "expression": "anonymous_function_use_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "array_element_initializer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "base_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "binary_expression_.",
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "php"
-        ],
+        "languages": ["php"],
         "operator": "."
     },
     {
@@ -6072,10 +4099,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "php",
-            "cpp"
-        ],
+        "languages": ["php", "cpp"],
         "operator": "<=>"
     },
     {
@@ -6083,3576 +4107,2678 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "php"
-        ],
+        "languages": ["php"],
         "operator": "<>"
     },
     {
         "expression": "binary_expression_and",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "php",
-            "cpp"
-        ],
+        "languages": ["php", "cpp"],
         "operator": "and"
     },
     {
         "expression": "binary_expression_or",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "php",
-            "cpp"
-        ],
+        "languages": ["php", "cpp"],
         "operator": "or"
     },
     {
         "expression": "binary_expression_xor",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "php",
-            "cpp"
-        ],
+        "languages": ["php", "cpp"],
         "operator": "xor"
     },
     {
         "expression": "case_statement",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "case_label",
-        "languages": [
-            "php",
-            "cpp"
-        ]
+        "languages": ["php", "cpp"]
     },
     {
         "expression": "cast_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "class_interface_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "colon_block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "const_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "declare_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "default_statement",
         "metrics": [],
         "type": "statement",
         "category": "default_label",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "else_if_clause",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "list_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "namespace_aliasing_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "namespace_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "namespace_name_as_prefix",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "namespace_use_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "namespace_use_group",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "namespace_use_group_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "property_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "property_initializer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "relative_scope",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "simple_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "static_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "static_variable_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "text",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "text_interpolation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "use_as_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "use_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "use_instead_of_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "use_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "variadic_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php",
-            "cpp"
-        ]
+        "languages": ["php", "cpp"]
     },
     {
         "expression": "variadic_unpacking",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "list",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "php_tag",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "var_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "conditional_type",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "existential_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "flow_maybe_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "index_type_query",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "literal_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "lookup_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "nested_type_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "object_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "type_query",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "abstract_class_declaration",
-        "metrics": [
-            "classes"
-        ],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "ambient_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "function_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "internal_module",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "type_alias_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "type_assertion",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts"
-        ]
+        "languages": ["ts"]
     },
     {
         "expression": "non_null_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "abstract_method_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "accessibility_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "asserts",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "call_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "constraint",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "construct_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "constructor_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "default_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "enum_assignment",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "extends_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "implements_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "import_require_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "index_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "infer_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "intersection_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "php",
-            "tsx"
-        ]
+        "languages": ["ts", "php", "tsx"]
     },
     {
         "expression": "mapped_type_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "method_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "omitting_type_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "opting_type_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "optional_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "property_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "readonly_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "required_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "rest_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "type_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "type_predicate",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "type_predicate_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "union_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "go",
-            "php",
-            "py",
-            "tsx"
-        ]
+        "languages": ["ts", "go", "php", "py", "tsx"]
     },
     {
         "expression": "class_definition",
-        "metrics": [
-            "classes"
-        ],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "decorated_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "delete_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "exec_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "future_import_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "import_from_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "nonlocal_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "pass_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "print_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "raise_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "boolean_operator",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "comparison_operator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "lambda",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "named_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "not_operator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "default_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "dictionary_splat_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "list_splat_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "typed_default_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "typed_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "list_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py",
-            "cs"
-        ]
+        "languages": ["py", "cs"]
     },
     {
         "expression": "subscript",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "binary_operator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "call",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "concatenated_string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py",
-            "cpp"
-        ]
+        "languages": ["py", "cpp"]
     },
     {
         "expression": "dictionary",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "dictionary_comprehension",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "ellipsis",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "generator_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "list_comprehension",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "none",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "set_comprehension",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "tuple",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "unary_operator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "aliased_import",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "augmented_assignment",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "chevron",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "dictionary_splat",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "dotted_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "elif_clause",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "except_clause",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "for_in_clause",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "format_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "format_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "if_clause",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "import_prefix",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "keyword_argument",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "list_splat",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "parenthesized_list_splat",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "pattern_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "relative_import",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "slice",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "wildcard_import",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "with_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "with_item",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "type_conversion",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "abstract_array_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "abstract_function_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "abstract_parenthesized_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "abstract_pointer_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "abstract_reference_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "array_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "attributed_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "destructor_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "function_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "operator_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "parenthesized_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "pointer_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "qualified_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "reference_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "structured_binding_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "template_function",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "char_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "co_await_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "compound_literal_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "delete_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "field_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "number_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "parameter_pack_expansion",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "pointer_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "sizeof_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "user_defined_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "template_method",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "co_return_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "co_yield_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "for_range_loop",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "auto",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "class_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "decltype",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "dependent_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "enum_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "sized_type_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "struct_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "template_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["cpp", "ts", "tsx"]
     },
     {
         "expression": "union_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "access_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "alias_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "attribute_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "attribute_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "attributed_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "base_class_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "bitfield_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "comma_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "condition_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "default_method_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "delete_method_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "dependent_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "enumerator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "enumerator_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "explicit_function_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "field_designator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "field_initializer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "field_initializer_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "friend_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "init_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "initializer_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "initializer_pair",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "lambda_capture_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "lambda_default_capture",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "linkage_specification",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "ms_based_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "ms_call_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "ms_declspec_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "ms_pointer_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "ms_unaligned_ptr_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "namespace_alias_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "new_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "noexcept",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "operator_cast",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "optional_parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "optional_type_parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_call",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_def",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_defined",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_elif",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_else",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_function_def",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_if",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_ifdef",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_include",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_params",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "ref_qualifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "static_assert_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "storage_class_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "subscript_designator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "template_argument_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "template_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "template_instantiation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "template_parameter_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "template_template_parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "throw_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "trailing_return_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "translation_unit",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "type_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "type_descriptor",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "type_parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "type_qualifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "using_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "variadic_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "variadic_type_parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "virtual_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "literal_suffix",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "ms_restrict_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "ms_signed_ptr_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "ms_unsigned_ptr_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "namespace_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_arg",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "system_lib_string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "record_struct_declaration",
-        "metrics": [
-            "classes"
-        ],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "and_pattern",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "define_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "elif_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "else_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "endregion_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "error_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "expression_colon",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "file_scoped_namespace_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "if_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "line_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "nullable_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "or_pattern",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "pragma_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "region_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "slice_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "undef_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "warning_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "endif_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "preproc_integer_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "preproc_message",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "preproc_string_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cs"
-        ]
+        "languages": ["cs"]
     },
     {
         "expression": "iota",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "negated_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "literal_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "struct_elem",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "struct_term",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "go"
-        ]
+        "languages": ["go"]
     },
     {
         "expression": "block_comment",
-        "metrics": [
-            "comment_lines",
-            "real_lines_of_code"
-        ],
+        "metrics": ["comment_lines", "real_lines_of_code"],
         "type": "statement",
         "category": "comment",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "line_comment",
-        "metrics": [
-            "comment_lines",
-            "real_lines_of_code"
-        ],
+        "metrics": ["comment_lines", "real_lines_of_code"],
         "type": "statement",
         "category": "comment",
-        "languages": [
-            "java",
-            "kt"
-        ]
+        "languages": ["java", "kt"]
     },
     {
         "expression": "exports_module_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "opens_module_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "provides_module_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "requires_module_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "uses_module_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "template_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "compact_constructor_declaration",
-        "metrics": [
-            "functions",
-            "complexity"
-        ],
+        "metrics": ["functions", "complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "condition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "guard",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "multiline_string_fragment",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "permits",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "record_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "record_pattern_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "record_pattern_component",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "string_interpolation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "switch_block_statement_group",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "switch_rule",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "type_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "php"
-        ]
+        "languages": ["java", "php"]
     },
     {
         "expression": "string_fragment",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java",
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["java", "js", "ts", "tsx"]
     },
     {
         "expression": "underscore_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "java"
-        ]
+        "languages": ["java"]
     },
     {
         "expression": "glimmer_template",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "class_static_block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "field_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js"
-        ]
+        "languages": ["js"]
     },
     {
         "expression": "glimmer_closing_tag",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "glimmer_opening_tag",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "namespace_export",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "optional_chain",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "private_property_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "character_escape_seq",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "function_value_parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "getter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "import_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "multi_variable_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "not_nullable_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "multiline_comment",
-        "metrics": [
-            "comment_lines",
-            "real_lines_of_code"
-        ],
+        "metrics": ["comment_lines", "real_lines_of_code"],
         "type": "statement",
         "category": "comment",
-        "languages": [
-            "kt"
-        ]
+        "languages": ["kt"]
     },
     {
         "expression": "match_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "reference_assignment_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "encapsed_string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "nowdoc",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "nullsafe_member_access_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "nullsafe_member_call_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "abstract_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "attribute_group",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "by_ref",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "enum_case",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "enum_declaration_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "final_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "heredoc_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "match_block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "match_condition_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "match_conditional_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "match_default_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "named_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "nowdoc_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "property_promotion_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "readonly_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "reference_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "variadic_placeholder",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "bottom_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "heredoc_end",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "heredoc_start",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "nowdoc_string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "string_value",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "php"
-        ]
+        "languages": ["php"]
     },
     {
         "expression": "template_literal_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "this_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "instantiation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "satisfies_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "asserts_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "extends_type_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "override_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "match_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "type_alias_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "as_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "keyword_separator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "positional_separator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "case_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "case_pattern",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "case_label",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "class_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "complex_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "constrained_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "dict_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "except_group_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "keyword_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "member_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "splat_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "splat_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "string_content",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py",
-            "cpp"
-        ]
+        "languages": ["py", "cpp"]
     },
     {
         "expression": "union_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "escape_interpolation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "line_continuation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "string_end",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "string_start",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "py"
-        ]
+        "languages": ["py"]
     },
     {
         "expression": "alignof_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "fold_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "generic_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "gnu_asm_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "offsetof_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "requires_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "requires_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "placeholder_type_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "alignas_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "binary_expression_bitand",
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cpp"
-        ],
+        "languages": ["cpp"],
         "operator": "bitand"
     },
     {
@@ -9660,9 +6786,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cpp"
-        ],
+        "languages": ["cpp"],
         "operator": "bitor"
     },
     {
@@ -9670,9 +6794,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": [
-            "cpp"
-        ],
+        "languages": ["cpp"],
         "operator": "not_eq"
     },
     {
@@ -9680,314 +6802,230 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "concept_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "constraint_conjunction",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "constraint_disjunction",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "gnu_asm_clobber_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "gnu_asm_goto_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "gnu_asm_input_operand",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "gnu_asm_input_operand_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "gnu_asm_output_operand",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "gnu_asm_output_operand_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "gnu_asm_qualifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "init_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "nested_namespace_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "pointer_type_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "preproc_elifdef",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "requirement_seq",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "simple_requirement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "subscript_argument_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "type_requirement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "character",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "raw_string_content",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "raw_string_delimiter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "function_expression",
-        "metrics": [
-            "complexity",
-            "functions"
-        ],
+        "metrics": ["complexity", "functions"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "import_attribute",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "html_character_reference",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "html_comment",
-        "metrics": [
-            "comment_lines",
-            "real_lines_of_code"
-        ],
+        "metrics": ["comment_lines", "real_lines_of_code"],
         "type": "statement",
         "category": "comment",
-        "languages": [
-            "js",
-            "ts",
-            "tsx"
-        ]
+        "languages": ["js", "ts", "tsx"]
     },
     {
         "expression": "const",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "adding_type_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "ts",
-            "tsx"
-        ]
+        "languages": ["ts", "tsx"]
     },
     {
         "expression": "seh_leave_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "seh_try_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "seh_except_clause",
-        "metrics": [
-            "complexity"
-        ],
+        "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "seh_finally_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     },
     {
         "expression": "subscript_range_designator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": [
-            "cpp"
-        ]
+        "languages": ["cpp"]
     }
 ]

--- a/src/parser/config/nodeTypesConfig.json
+++ b/src/parser/config/nodeTypesConfig.json
@@ -1,829 +1,1315 @@
 [
     {
         "expression": "class_declaration",
-        "metrics": ["classes"],
+        "metrics": [
+            "classes"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "kt", "php", "ts"]
+        "languages": [
+            "cs",
+            "java",
+            "js",
+            "kt",
+            "php",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "constructor_declaration",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java"]
+        "languages": [
+            "cs",
+            "java"
+        ]
     },
     {
         "expression": "conversion_operator_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "delegate_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "destructor_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "enum_declaration",
-        "metrics": ["classes"],
+        "metrics": [
+            "classes"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "ts", "php"]
+        "languages": [
+            "cs",
+            "java",
+            "ts",
+            "php",
+            "tsx"
+        ]
     },
     {
         "expression": "event_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "event_field_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "field_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "cpp"
+        ]
     },
     {
         "expression": "indexer_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "interface_declaration",
-        "metrics": ["classes"],
+        "metrics": [
+            "classes"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "php", "ts"]
+        "languages": [
+            "cs",
+            "java",
+            "php",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "method_declaration",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "php"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "php"
+        ]
     },
     {
         "expression": "namespace_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "operator_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "property_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "kt", "php"]
+        "languages": [
+            "cs",
+            "kt",
+            "php"
+        ]
     },
     {
         "expression": "record_declaration",
-        "metrics": ["classes"],
+        "metrics": [
+            "classes"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java"]
+        "languages": [
+            "cs",
+            "java"
+        ]
     },
     {
         "expression": "struct_declaration",
-        "metrics": ["classes"],
+        "metrics": [
+            "classes"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "using_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "anonymous_method_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "anonymous_object_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "array_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "php"]
+        "languages": [
+            "cs",
+            "java",
+            "php"
+        ]
     },
     {
         "expression": "as_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "kt", "ts"]
+        "languages": [
+            "cs",
+            "kt",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "assignment_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "php", "ts", "cpp"]
+        "languages": [
+            "cs",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "await_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "js", "ts"]
+        "languages": [
+            "cs",
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "base_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "binary_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "boolean_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "kt"]
+        "languages": [
+            "cs",
+            "kt"
+        ]
     },
     {
         "expression": "cast_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "php", "cpp"]
+        "languages": [
+            "cs",
+            "java",
+            "php",
+            "cpp"
+        ]
     },
     {
         "expression": "character_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "kt"]
+        "languages": [
+            "cs",
+            "java",
+            "kt"
+        ]
     },
     {
         "expression": "checked_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "conditional_access_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "conditional_expression",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "php", "py", "cpp"]
+        "languages": [
+            "cs",
+            "php",
+            "py",
+            "cpp"
+        ]
     },
     {
         "expression": "default_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "element_access_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "element_binding_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "generic_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "global",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "kt", "ts", "py", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "kt",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "implicit_array_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "implicit_object_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "implicit_stack_alloc_array_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "initializer_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "integer_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "kt"]
+        "languages": [
+            "cs",
+            "kt"
+        ]
     },
     {
         "expression": "interpolated_string_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "invocation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "is_expression",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "is_pattern_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "lambda_expression",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "cpp"]
+        "languages": [
+            "cs",
+            "java",
+            "cpp"
+        ]
     },
     {
         "expression": "make_ref_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "member_access_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "php"]
+        "languages": [
+            "cs",
+            "php"
+        ]
     },
     {
         "expression": "null_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java"]
+        "languages": [
+            "cs",
+            "java"
+        ]
     },
     {
         "expression": "object_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "php"]
+        "languages": [
+            "cs",
+            "java",
+            "php"
+        ]
     },
     {
         "expression": "parenthesized_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "kt", "php", "ts", "py", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "kt",
+            "php",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "postfix_unary_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "prefix_unary_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "query_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "range_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "kt"]
+        "languages": [
+            "cs",
+            "kt"
+        ]
     },
     {
         "expression": "real_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "kt"]
+        "languages": [
+            "cs",
+            "kt"
+        ]
     },
     {
         "expression": "ref_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "ref_type_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "ref_value_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "size_of_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "stack_alloc_array_creation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "string_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "cpp", "kt"]
+        "languages": [
+            "cs",
+            "java",
+            "cpp",
+            "kt"
+        ]
     },
     {
         "expression": "switch_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java"]
+        "languages": [
+            "cs",
+            "java"
+        ]
     },
     {
         "expression": "this_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "kt"]
+        "languages": [
+            "cs",
+            "kt"
+        ]
     },
     {
         "expression": "throw_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "php"]
+        "languages": [
+            "cs",
+            "php"
+        ]
     },
     {
         "expression": "tuple_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "type_of_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "verbatim_string_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "with_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "py"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "py"
+        ]
     },
     {
         "expression": "break_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "checked_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "continue_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "do_statement",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "php", "ts", "cpp"]
+        "languages": [
+            "cs",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "empty_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "js", "php", "ts"]
+        "languages": [
+            "cs",
+            "go",
+            "js",
+            "php",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "expression_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "php", "ts", "py", "cpp", "go"]
+        "languages": [
+            "cs",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "py",
+            "cpp",
+            "go",
+            "tsx"
+        ]
     },
     {
         "expression": "fixed_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "for_each_statement",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "for_statement",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "kt", "php", "ts", "py", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "kt",
+            "php",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "goto_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "php", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "php",
+            "cpp"
+        ]
     },
     {
         "expression": "if_statement",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "labeled_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "ts", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "local_declaration_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "local_function_statement",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "lock_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "return_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "switch_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "js", "php", "ts", "cpp"]
+        "languages": [
+            "cs",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "throw_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "ts", "cpp"]
+        "languages": [
+            "cs",
+            "java",
+            "js",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "try_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "php", "ts", "py", "cpp"]
+        "languages": [
+            "cs",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "unsafe_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "using_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "while_statement",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "kt", "php", "ts", "py", "cpp"]
+        "languages": [
+            "cs",
+            "java",
+            "js",
+            "kt",
+            "php",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "yield_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java"]
+        "languages": [
+            "cs",
+            "java"
+        ]
     },
     {
         "expression": "alias_qualified_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "array_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "ts"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "function_pointer_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "implicit_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "nullable_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "kt"]
+        "languages": [
+            "cs",
+            "kt"
+        ]
     },
     {
         "expression": "pointer_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go"]
+        "languages": [
+            "cs",
+            "go"
+        ]
     },
     {
         "expression": "predefined_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "ts"]
+        "languages": [
+            "cs",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "qualified_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "php"]
+        "languages": [
+            "cs",
+            "php"
+        ]
     },
     {
         "expression": "tuple_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "ts"]
+        "languages": [
+            "cs",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "accessor_declaration",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "accessor_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "argument",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "php"]
+        "languages": [
+            "cs",
+            "php"
+        ]
     },
     {
         "expression": "argument_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "py", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "py",
+            "cpp"
+        ]
     },
     {
         "expression": "array_rank_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "arrow_expression_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "assignment_operator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "attribute",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "py", "cpp", "php"]
+        "languages": [
+            "cs",
+            "py",
+            "cpp",
+            "php"
+        ]
     },
     {
         "expression": "attribute_argument",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "attribute_argument_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "attribute_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "php"]
+        "languages": [
+            "cs",
+            "php"
+        ]
     },
     {
         "expression": "attribute_target_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "base_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "binary_expression_!=",
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "!="
     },
     {
@@ -831,7 +1317,16 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "%"
     },
     {
@@ -839,15 +1334,35 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "&"
     },
     {
         "expression": "binary_expression_&&",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "&&"
     },
     {
@@ -855,7 +1370,16 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "*"
     },
     {
@@ -863,7 +1387,16 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "+"
     },
     {
@@ -871,7 +1404,16 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "-"
     },
     {
@@ -879,7 +1421,16 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "/"
     },
     {
@@ -887,7 +1438,16 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "<"
     },
     {
@@ -895,7 +1455,16 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "<<"
     },
     {
@@ -903,7 +1472,16 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "<="
     },
     {
@@ -911,7 +1489,16 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "=="
     },
     {
@@ -919,7 +1506,16 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": ">"
     },
     {
@@ -927,7 +1523,16 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": ">="
     },
     {
@@ -935,15 +1540,32 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": ">>"
     },
     {
         "expression": "binary_expression_??",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "js", "ts", "php"],
+        "languages": [
+            "cs",
+            "js",
+            "ts",
+            "php",
+            "tsx"
+        ],
         "operator": "??"
     },
     {
@@ -951,7 +1573,16 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "^"
     },
     {
@@ -959,15 +1590,35 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "|"
     },
     {
         "expression": "binary_expression_||",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp"],
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ],
         "operator": "||"
     },
     {
@@ -975,1430 +1626,2009 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "bracketed_parameter_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "case_pattern_switch_label",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "case_label",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "case_switch_label",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "case_label",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "catch_clause",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "php", "ts", "cpp"]
+        "languages": [
+            "cs",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "catch_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "catch_filter_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "compilation_unit",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "constant_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "constructor_constraint",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "constructor_initializer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "declaration_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "declaration_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "php", "cpp"]
+        "languages": [
+            "cs",
+            "php",
+            "cpp"
+        ]
     },
     {
         "expression": "declaration_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "default_switch_label",
         "metrics": [],
         "type": "statement",
         "category": "default_label",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "enum_member_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "enum_member_declaration_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "equals_value_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "explicit_interface_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "extern_alias_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "finally_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "php", "ts", "py"]
+        "languages": [
+            "cs",
+            "java",
+            "js",
+            "php",
+            "ts",
+            "py",
+            "tsx"
+        ]
     },
     {
         "expression": "from_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "function_pointer_calling_convention",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "function_pointer_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "function_pointer_unmanaged_calling_convention",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "function_pointer_unmanaged_calling_convention_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "global_attribute_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "global_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "py"]
+        "languages": [
+            "cs",
+            "py"
+        ]
     },
     {
         "expression": "group_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "interpolated_string_text",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "interpolated_verbatim_string_text",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "interpolation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "py"]
+        "languages": [
+            "cs",
+            "py"
+        ]
     },
     {
         "expression": "interpolation_alignment_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "interpolation_format_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "join_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "join_into_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "label_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "let_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "member_binding_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "name_colon",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "name_equals",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "negated_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "order_by_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "kt"]
+        "languages": [
+            "cs",
+            "kt"
+        ]
     },
     {
         "expression": "parameter_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "cpp"
+        ]
     },
     {
         "expression": "parameter_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "kt"]
+        "languages": [
+            "cs",
+            "kt"
+        ]
     },
     {
         "expression": "parenthesized_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "parenthesized_variable_designation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "positional_pattern_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "primary_constructor_base_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "property_pattern_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "query_continuation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "recursive_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "relational_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "select_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "simple_assignment_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "subpattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "switch_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "js", "ts"]
+        "languages": [
+            "cs",
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "switch_expression_arm",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "switch_section",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "tuple_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "tuple_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "py"]
+        "languages": [
+            "cs",
+            "py"
+        ]
     },
     {
         "expression": "type_argument_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "type_constraint",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "kt"]
+        "languages": [
+            "cs",
+            "kt"
+        ]
     },
     {
         "expression": "type_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "kt", "ts", "py"]
+        "languages": [
+            "cs",
+            "java",
+            "kt",
+            "ts",
+            "py",
+            "tsx"
+        ]
     },
     {
         "expression": "type_parameter_constraint",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "type_parameter_constraints_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "type_parameter_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go"]
+        "languages": [
+            "cs",
+            "go"
+        ]
     },
     {
         "expression": "type_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java"]
+        "languages": [
+            "cs",
+            "java"
+        ]
     },
     {
         "expression": "var_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "variable_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "js", "kt", "ts"]
+        "languages": [
+            "cs",
+            "js",
+            "kt",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "variable_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "ts"]
+        "languages": [
+            "cs",
+            "java",
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "when_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "where_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "with_initializer_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": ";",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "await",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "class",
-        "metrics": ["classes"],
+        "metrics": [
+            "classes"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "comment",
-        "metrics": ["comment_lines", "real_lines_of_code"],
+        "metrics": [
+            "comment_lines",
+            "real_lines_of_code"
+        ],
         "type": "statement",
         "category": "comment",
-        "languages": ["cs", "go", "js", "php", "ts", "py", "cpp"]
+        "languages": [
+            "cs",
+            "go",
+            "js",
+            "php",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "discard",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "escape_sequence",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "js", "ts", "py", "cpp", "java", "php"]
+        "languages": [
+            "cs",
+            "go",
+            "js",
+            "ts",
+            "py",
+            "cpp",
+            "java",
+            "php",
+            "tsx"
+        ]
     },
     {
         "expression": "false",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["go", "java", "js", "ts", "py", "cpp"]
+        "languages": [
+            "go",
+            "java",
+            "js",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "module",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "activated_for_languages": ["py"],
-        "languages": ["ts", "py"]
+        "activated_for_languages": [
+            "py"
+        ],
+        "languages": [
+            "ts",
+            "py",
+            "tsx"
+        ]
     },
     {
         "expression": "set",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "this",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["java", "js", "ts", "cpp"]
+        "languages": [
+            "java",
+            "js",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "true",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["go", "java", "js", "ts", "py", "cpp"]
+        "languages": [
+            "go",
+            "java",
+            "js",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "type",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "virtual",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "void_keyword",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "yield",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "call_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "js", "kt", "ts", "cpp"]
+        "languages": [
+            "go",
+            "js",
+            "kt",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "composite_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "float_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "func_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "imaginary_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "index_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "int_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "interpreted_string_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "nil",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "raw_string_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "cpp"]
+        "languages": [
+            "go",
+            "cpp"
+        ]
     },
     {
         "expression": "rune_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "selector_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "slice_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "type_assertion_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "type_conversion_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "unary_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "java", "js", "ts", "cpp"]
+        "languages": [
+            "go",
+            "java",
+            "js",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "_simple_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "assignment_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "dec_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "inc_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "send_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "short_var_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "_simple_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "java"]
+        "languages": [
+            "go",
+            "java"
+        ]
     },
     {
         "expression": "channel_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "function_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "kt", "ts"]
+        "languages": [
+            "go",
+            "kt",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "interface_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "map_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "qualified_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "slice_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "struct_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "type_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "java", "kt", "ts", "cpp"]
+        "languages": [
+            "go",
+            "java",
+            "kt",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "const_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "php"]
+        "languages": [
+            "go",
+            "php"
+        ]
     },
     {
         "expression": "defer_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "expression_switch_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "fallthrough_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "go_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "select_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "type_declaration",
-        "metrics": ["classes"],
+        "metrics": [
+            "classes"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "type_switch_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "var_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "parenthesized_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "kt", "ts"]
+        "languages": [
+            "go",
+            "kt",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "binary_expression_&^",
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["go"],
+        "languages": [
+            "go"
+        ],
         "operator": "&^"
     },
     {
         "expression": "communication_case",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "case_label",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "const_spec",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "default_case",
         "metrics": [],
         "type": "statement",
         "category": "default_label",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "dot",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "expression_case",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "case_label",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "expression_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "py"]
+        "languages": [
+            "go",
+            "py"
+        ]
     },
     {
         "expression": "field_declaration_list",
-        "metrics": ["classes"],
+        "metrics": [
+            "classes"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["go", "cpp"]
+        "languages": [
+            "go",
+            "cpp"
+        ]
     },
     {
         "expression": "for_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "function_declaration",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["go", "js", "kt", "ts"]
+        "languages": [
+            "go",
+            "js",
+            "kt",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "implicit_length_array_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "import_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "java"]
+        "languages": [
+            "go",
+            "java"
+        ]
     },
     {
         "expression": "import_spec",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "import_spec_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "keyed_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "literal_value",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "method_spec",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "package_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "cpp"]
+        "languages": [
+            "go",
+            "cpp"
+        ]
     },
     {
         "expression": "range_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "receive_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "source_file",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "kt"]
+        "languages": [
+            "go",
+            "kt"
+        ]
     },
     {
         "expression": "type_alias",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "kt"]
+        "languages": [
+            "go",
+            "kt"
+        ]
     },
     {
         "expression": "type_case",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "case_label",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "type_spec",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "var_spec",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "variadic_argument",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "variadic_parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "cpp"]
+        "languages": [
+            "go",
+            "cpp"
+        ]
     },
     {
         "expression": "blank_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "field_identifier",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["go", "cpp"]
+        "languages": [
+            "go",
+            "cpp"
+        ]
     },
     {
         "expression": "import",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "package_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "php"]
+        "languages": [
+            "java",
+            "php"
+        ]
     },
     {
         "expression": "binary_integer_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "decimal_floating_point_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "decimal_integer_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "hex_floating_point_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "hex_integer_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "octal_integer_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "boolean_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "floating_point_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "generic_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "ts", "go", "py"]
+        "languages": [
+            "java",
+            "ts",
+            "go",
+            "py",
+            "tsx"
+        ]
     },
     {
         "expression": "integral_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "scoped_type_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "void_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "_unannotated_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "annotated_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "js", "ts", "cpp"]
+        "languages": [
+            "java",
+            "js",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "annotation_type_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "module_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "package_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "instanceof_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "primary_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "js", "ts", "py"]
+        "languages": [
+            "java",
+            "js",
+            "ts",
+            "py",
+            "tsx"
+        ]
     },
     {
         "expression": "ternary_expression",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["java", "js", "ts"]
+        "languages": [
+            "java",
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "update_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "js", "php", "ts", "cpp"]
+        "languages": [
+            "java",
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "array_access",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "class_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "field_access",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "method_invocation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "method_reference",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "assert_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "py"]
+        "languages": [
+            "java",
+            "py"
+        ]
     },
     {
         "expression": "enhanced_for_statement",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "local_variable_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "synchronized_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "try_with_resources_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "kt"]
+        "languages": [
+            "java",
+            "kt"
+        ]
     },
     {
         "expression": "annotation_argument_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "annotation_type_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "annotation_type_element_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "array_initializer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "asterisk",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "binary_expression_>>>",
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["java", "js", "ts"],
+        "languages": [
+            "java",
+            "js",
+            "ts",
+            "tsx"
+        ],
         "operator": ">>>"
     },
     {
@@ -2406,511 +3636,780 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "catch_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "class_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "js", "kt", "ts"]
+        "languages": [
+            "java",
+            "js",
+            "kt",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "constant_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "constructor_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "dimensions",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "dimensions_expr",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "element_value_array_initializer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "element_value_pair",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "enum_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "ts"]
+        "languages": [
+            "java",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "enum_body_declarations",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "enum_constant",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "explicit_constructor_invocation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "extends_interfaces",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "formal_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "formal_parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "js", "php", "ts"]
+        "languages": [
+            "java",
+            "js",
+            "php",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "inferred_parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "interface_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "ts"]
+        "languages": [
+            "java",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "marker_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "modifiers",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "kt"]
+        "languages": [
+            "java",
+            "kt"
+        ]
     },
     {
         "expression": "module_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "program",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "js", "php", "ts"]
+        "languages": [
+            "java",
+            "js",
+            "php",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "receiver_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "requires_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "resource",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "resource_specification",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "scoped_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "spread_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "static_initializer",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "super_interfaces",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "superclass",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "switch_block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "php"]
+        "languages": [
+            "java",
+            "php"
+        ]
     },
     {
         "expression": "switch_label",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "case_label",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "throws",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "type_arguments",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "kt", "ts", "go"]
+        "languages": [
+            "java",
+            "kt",
+            "ts",
+            "go",
+            "tsx"
+        ]
     },
     {
         "expression": "type_bound",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "type_parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "kt", "ts"]
+        "languages": [
+            "java",
+            "kt",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "wildcard",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "float",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["php", "py"]
+        "languages": [
+            "php",
+            "py"
+        ]
     },
     {
         "expression": "super",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["java", "js", "ts"]
+        "languages": [
+            "java",
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "generator_function_declaration",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "lexical_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "augmented_assignment_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "php", "ts"]
+        "languages": [
+            "js",
+            "php",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "jsx_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "jsx_self_closing_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "new_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts", "cpp"]
+        "languages": [
+            "js",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "yield_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "php", "ts"]
+        "languages": [
+            "js",
+            "php",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "array_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "object_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "rest_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "array",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "arrow_function",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts", "php"]
+        "languages": [
+            "js",
+            "ts",
+            "php",
+            "tsx"
+        ]
     },
     {
         "expression": "generator_function",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "member_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "meta_property",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "null",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["js", "php", "ts", "cpp"]
+        "languages": [
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "number",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "object",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "regex",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "php", "ts", "py"]
+        "languages": [
+            "js",
+            "php",
+            "ts",
+            "py",
+            "tsx"
+        ]
     },
     {
         "expression": "subscript_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "php", "ts", "cpp"]
+        "languages": [
+            "js",
+            "php",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "template_string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "undefined",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "debugger_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "export_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "for_in_statement",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "import_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts", "py"]
+        "languages": [
+            "js",
+            "ts",
+            "py",
+            "tsx"
+        ]
     },
     {
         "expression": "statement_block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "with_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts", "py"]
+        "languages": [
+            "js",
+            "ts",
+            "py",
+            "tsx"
+        ]
     },
     {
         "expression": "arguments",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "php", "ts"]
+        "languages": [
+            "js",
+            "php",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "assignment_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "binary_expression_!==",
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["js", "php", "ts"],
+        "languages": [
+            "js",
+            "php",
+            "ts",
+            "tsx"
+        ],
         "operator": "!=="
     },
     {
@@ -2918,7 +4417,11 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["js", "ts"],
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ],
         "operator": "**"
     },
     {
@@ -2926,7 +4429,12 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["js", "php", "ts"],
+        "languages": [
+            "js",
+            "php",
+            "ts",
+            "tsx"
+        ],
         "operator": "==="
     },
     {
@@ -2934,7 +4442,11 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["js", "ts"],
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ],
         "operator": "in"
     },
     {
@@ -2942,7 +4454,12 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["js", "php", "ts"],
+        "languages": [
+            "js",
+            "php",
+            "ts",
+            "tsx"
+        ],
         "operator": "instanceof"
     },
     {
@@ -2950,1148 +4467,1604 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "computed_property_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "decorator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts", "py"]
+        "languages": [
+            "js",
+            "ts",
+            "py",
+            "tsx"
+        ]
     },
     {
         "expression": "else_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "php", "ts", "py", "cpp"]
+        "languages": [
+            "js",
+            "php",
+            "ts",
+            "py",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "export_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "export_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "import_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "import_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "jsx_attribute",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "jsx_closing_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "jsx_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "jsx_namespace_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "jsx_opening_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "method_definition",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "named_imports",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "namespace_import",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "nested_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "object_assignment_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "pair",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "php", "ts", "py"]
+        "languages": [
+            "js",
+            "php",
+            "ts",
+            "py",
+            "tsx"
+        ]
     },
     {
         "expression": "pair_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "public_field_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "sequence_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "php", "ts"]
+        "languages": [
+            "js",
+            "php",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "spread_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "switch_case",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "case_label",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "switch_default",
         "metrics": [],
         "type": "statement",
         "category": "default_label",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "template_substitution",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "hash_bang_line",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "jsx_text",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "property_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "regex_flags",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "regex_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "shorthand_property_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "shorthand_property_identifier_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "statement_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts", "cpp"]
+        "languages": [
+            "js",
+            "ts",
+            "cpp",
+            "tsx"
+        ]
     },
     {
         "expression": "additive_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "annotated_lambda",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "anonymous_function",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "anonymous_initializer",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "assignment",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt", "py"]
+        "languages": [
+            "kt",
+            "py"
+        ]
     },
     {
         "expression": "call_suffix",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "callable_reference",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "catch_block",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "check_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "class_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "class_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "collection_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "companion_object",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "comparison_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "conjunction_expression",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "constructor_delegation_call",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "constructor_invocation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "control_structure_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "delegation_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "directly_assignable_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "disjunction_expression",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "do_while_statement",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "elvis_expression",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "enum_class_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "enum_entry",
-        "metrics": ["classes"],
+        "metrics": [
+            "classes"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "equality_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "explicit_delegation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "file_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "finally_block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "function_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "function_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "function_type_parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "if_expression",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "import_alias",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt", "ts"]
+        "languages": [
+            "kt",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "import_header",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "indexing_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "indexing_suffix",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "infix_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "inheritance_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "interpolated_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "interpolated_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "jump_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "lambda_literal",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "lambda_parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt", "py"]
+        "languages": [
+            "kt",
+            "py"
+        ]
     },
     {
         "expression": "long_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "member_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "multiplicative_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "navigation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "navigation_suffix",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "object_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "object_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "package_header",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "parameter_modifiers",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "parameter_with_optional_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "parenthesized_user_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "platform_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "postfix_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "prefix_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "primary_constructor",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "property_delegate",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "range_test",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "secondary_constructor",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "setter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "shebang_line",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "simple_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "spread_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "statements",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "super_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "try_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "type_constraints",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "type_modifiers",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "type_parameter_modifiers",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "type_projection",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "type_projection_modifiers",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "type_test",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "unsigned_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "use_site_target",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "user_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "value_argument",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "value_arguments",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "variance_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "visibility_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt", "php"]
+        "languages": [
+            "kt",
+            "php"
+        ]
     },
     {
         "expression": "when_condition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "when_entry",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "case_label",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "when_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "when_subject",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "bin_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "hex_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "label",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "property_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "reification_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "_primary_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "clone_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "exponentiation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "include_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "include_once_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "require_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "require_once_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "unary_op_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "boolean",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "heredoc",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "integer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php", "py"]
+        "languages": [
+            "php",
+            "py"
+        ]
     },
     {
         "expression": "anonymous_function_creation_expression",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "class_constant_access_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "dynamic_variable_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "function_call_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "member_call_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "print_intrinsic",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "scoped_call_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "scoped_property_access_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "shell_command_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "variable_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "compound_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php", "cpp"]
+        "languages": [
+            "php",
+            "cpp"
+        ]
     },
     {
         "expression": "declare_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "echo_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "foreach_statement",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "function_definition",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["php", "py", "cpp"]
+        "languages": [
+            "php",
+            "py",
+            "cpp"
+        ]
     },
     {
         "expression": "function_static_declaration",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "global_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "named_label_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "namespace_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php", "cpp"]
+        "languages": [
+            "php",
+            "cpp"
+        ]
     },
     {
         "expression": "namespace_use_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "trait_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "unset_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "optional_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php", "ts"]
+        "languages": [
+            "php",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "primitive_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php", "cpp"]
+        "languages": [
+            "php",
+            "cpp"
+        ]
     },
     {
         "expression": "anonymous_function_use_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "array_element_initializer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "base_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "binary_expression_.",
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["php"],
+        "languages": [
+            "php"
+        ],
         "operator": "."
     },
     {
@@ -4099,7 +6072,10 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["php", "cpp"],
+        "languages": [
+            "php",
+            "cpp"
+        ],
         "operator": "<=>"
     },
     {
@@ -4107,2678 +6083,3576 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["php"],
+        "languages": [
+            "php"
+        ],
         "operator": "<>"
     },
     {
         "expression": "binary_expression_and",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["php", "cpp"],
+        "languages": [
+            "php",
+            "cpp"
+        ],
         "operator": "and"
     },
     {
         "expression": "binary_expression_or",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["php", "cpp"],
+        "languages": [
+            "php",
+            "cpp"
+        ],
         "operator": "or"
     },
     {
         "expression": "binary_expression_xor",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["php", "cpp"],
+        "languages": [
+            "php",
+            "cpp"
+        ],
         "operator": "xor"
     },
     {
         "expression": "case_statement",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "case_label",
-        "languages": ["php", "cpp"]
+        "languages": [
+            "php",
+            "cpp"
+        ]
     },
     {
         "expression": "cast_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "class_interface_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "colon_block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "const_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "declare_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "default_statement",
         "metrics": [],
         "type": "statement",
         "category": "default_label",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "else_if_clause",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "list_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "namespace_aliasing_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "namespace_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "namespace_name_as_prefix",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "namespace_use_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "namespace_use_group",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "namespace_use_group_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "property_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "property_initializer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "relative_scope",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "simple_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "static_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "static_variable_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "text",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "text_interpolation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "use_as_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "use_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "use_instead_of_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "use_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "variadic_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php", "cpp"]
+        "languages": [
+            "php",
+            "cpp"
+        ]
     },
     {
         "expression": "variadic_unpacking",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "list",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "php_tag",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "var_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "conditional_type",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "existential_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "flow_maybe_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "index_type_query",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "literal_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "lookup_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "nested_type_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "object_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "type_query",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "abstract_class_declaration",
-        "metrics": ["classes"],
+        "metrics": [
+            "classes"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "ambient_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "function_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "internal_module",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "type_alias_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "type_assertion",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts"
+        ]
     },
     {
         "expression": "non_null_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "abstract_method_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "accessibility_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "asserts",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "call_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "constraint",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "construct_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "constructor_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "default_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "enum_assignment",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "extends_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "implements_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "import_require_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "index_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "infer_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "intersection_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts", "php"]
+        "languages": [
+            "ts",
+            "php",
+            "tsx"
+        ]
     },
     {
         "expression": "mapped_type_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "method_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "omitting_type_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "opting_type_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "optional_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "property_signature",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "readonly_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "required_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "rest_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "type_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "type_predicate",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "type_predicate_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "union_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts", "go", "php", "py"]
+        "languages": [
+            "ts",
+            "go",
+            "php",
+            "py",
+            "tsx"
+        ]
     },
     {
         "expression": "class_definition",
-        "metrics": ["classes"],
+        "metrics": [
+            "classes"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "decorated_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "delete_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "exec_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "future_import_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "import_from_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "nonlocal_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "pass_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "print_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "raise_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "boolean_operator",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "comparison_operator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "lambda",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "named_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "not_operator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "default_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "dictionary_splat_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "list_splat_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "typed_default_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "typed_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "list_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py", "cs"]
+        "languages": [
+            "py",
+            "cs"
+        ]
     },
     {
         "expression": "subscript",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "binary_operator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "call",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "concatenated_string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py", "cpp"]
+        "languages": [
+            "py",
+            "cpp"
+        ]
     },
     {
         "expression": "dictionary",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "dictionary_comprehension",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "ellipsis",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "generator_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "list_comprehension",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "none",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "set_comprehension",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "tuple",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "unary_operator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "aliased_import",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "augmented_assignment",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "chevron",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "dictionary_splat",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "dotted_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "elif_clause",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "except_clause",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "for_in_clause",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "format_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "format_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "if_clause",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "import_prefix",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "keyword_argument",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "list_splat",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "parenthesized_list_splat",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "pattern_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "relative_import",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "slice",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "wildcard_import",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "with_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "with_item",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "type_conversion",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "abstract_array_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "abstract_function_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "abstract_parenthesized_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "abstract_pointer_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "abstract_reference_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "array_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "attributed_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "destructor_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "function_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "operator_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "parenthesized_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "pointer_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "qualified_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "reference_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "structured_binding_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "template_function",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "char_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "co_await_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "compound_literal_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "delete_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "field_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "number_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "parameter_pack_expansion",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "pointer_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "sizeof_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "user_defined_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "template_method",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "co_return_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "co_yield_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "for_range_loop",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "auto",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "class_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "decltype",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "dependent_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "enum_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "sized_type_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "struct_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "template_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp", "ts"]
+        "languages": [
+            "cpp",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "union_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "access_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "alias_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "attribute_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "attribute_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "attributed_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "base_class_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "bitfield_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "comma_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "condition_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "default_method_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "delete_method_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "dependent_name",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "enumerator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "enumerator_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "explicit_function_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "field_designator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "field_initializer",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "field_initializer_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "friend_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "init_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "initializer_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "initializer_pair",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "lambda_capture_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "lambda_default_capture",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "linkage_specification",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "ms_based_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "ms_call_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "ms_declspec_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "ms_pointer_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "ms_unaligned_ptr_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "namespace_alias_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "new_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "noexcept",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "operator_cast",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "optional_parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "optional_type_parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_call",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_def",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_defined",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_elif",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_else",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_function_def",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_if",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_ifdef",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_include",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_params",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "ref_qualifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "static_assert_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "storage_class_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "subscript_designator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "template_argument_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "template_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "template_instantiation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "template_parameter_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "template_template_parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "throw_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "trailing_return_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "translation_unit",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "type_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "type_descriptor",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "type_parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "type_qualifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "using_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "variadic_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "variadic_type_parameter_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "virtual_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "literal_suffix",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "ms_restrict_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "ms_signed_ptr_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "ms_unsigned_ptr_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "namespace_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_arg",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "system_lib_string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "record_struct_declaration",
-        "metrics": ["classes"],
+        "metrics": [
+            "classes"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "and_pattern",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "define_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "elif_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "else_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "endregion_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "error_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "expression_colon",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "file_scoped_namespace_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "if_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "line_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "nullable_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "or_pattern",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "pragma_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "region_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "slice_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "undef_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "warning_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "endif_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "preproc_integer_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "preproc_message",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "preproc_string_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs"]
+        "languages": [
+            "cs"
+        ]
     },
     {
         "expression": "iota",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "negated_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "literal_element",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "struct_elem",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "struct_term",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go"]
+        "languages": [
+            "go"
+        ]
     },
     {
         "expression": "block_comment",
-        "metrics": ["comment_lines", "real_lines_of_code"],
+        "metrics": [
+            "comment_lines",
+            "real_lines_of_code"
+        ],
         "type": "statement",
         "category": "comment",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "line_comment",
-        "metrics": ["comment_lines", "real_lines_of_code"],
+        "metrics": [
+            "comment_lines",
+            "real_lines_of_code"
+        ],
         "type": "statement",
         "category": "comment",
-        "languages": ["java", "kt"]
+        "languages": [
+            "java",
+            "kt"
+        ]
     },
     {
         "expression": "exports_module_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "opens_module_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "provides_module_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "requires_module_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "uses_module_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "template_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "compact_constructor_declaration",
-        "metrics": ["functions", "complexity"],
+        "metrics": [
+            "functions",
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "condition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "guard",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "multiline_string_fragment",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "permits",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "record_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "record_pattern_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "record_pattern_component",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "string_interpolation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "switch_block_statement_group",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "switch_rule",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "type_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "php"]
+        "languages": [
+            "java",
+            "php"
+        ]
     },
     {
         "expression": "string_fragment",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "js", "ts"]
+        "languages": [
+            "java",
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "underscore_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java"]
+        "languages": [
+            "java"
+        ]
     },
     {
         "expression": "glimmer_template",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "class_static_block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "field_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js"]
+        "languages": [
+            "js"
+        ]
     },
     {
         "expression": "glimmer_closing_tag",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "glimmer_opening_tag",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "namespace_export",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "optional_chain",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "private_property_identifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "character_escape_seq",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "function_value_parameters",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "getter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "import_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "multi_variable_declaration",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "not_nullable_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "multiline_comment",
-        "metrics": ["comment_lines", "real_lines_of_code"],
+        "metrics": [
+            "comment_lines",
+            "real_lines_of_code"
+        ],
         "type": "statement",
         "category": "comment",
-        "languages": ["kt"]
+        "languages": [
+            "kt"
+        ]
     },
     {
         "expression": "match_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "reference_assignment_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "encapsed_string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "nowdoc",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "nullsafe_member_access_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "nullsafe_member_call_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "abstract_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "attribute_group",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "by_ref",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "enum_case",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "enum_declaration_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "final_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "heredoc_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "match_block",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "match_condition_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "match_conditional_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "match_default_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "named_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "nowdoc_body",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "property_promotion_parameter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "readonly_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "reference_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "variadic_placeholder",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "bottom_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "heredoc_end",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "heredoc_start",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "nowdoc_string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "string_value",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php"]
+        "languages": [
+            "php"
+        ]
     },
     {
         "expression": "template_literal_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "this_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "instantiation_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "satisfies_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "asserts_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "extends_type_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "override_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "match_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "type_alias_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "as_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "keyword_separator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "positional_separator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "case_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "case_pattern",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "case_label",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "class_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "complex_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "constrained_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "dict_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "except_group_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "keyword_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "member_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "splat_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "splat_type",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "string_content",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py", "cpp"]
+        "languages": [
+            "py",
+            "cpp"
+        ]
     },
     {
         "expression": "union_pattern",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "escape_interpolation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "line_continuation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "string_end",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "string_start",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py"]
+        "languages": [
+            "py"
+        ]
     },
     {
         "expression": "alignof_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "fold_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "generic_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "gnu_asm_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "offsetof_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "requires_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "requires_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "placeholder_type_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "alignas_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "binary_expression_bitand",
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cpp"],
+        "languages": [
+            "cpp"
+        ],
         "operator": "bitand"
     },
     {
@@ -6786,7 +9660,9 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cpp"],
+        "languages": [
+            "cpp"
+        ],
         "operator": "bitor"
     },
     {
@@ -6794,7 +9670,9 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cpp"],
+        "languages": [
+            "cpp"
+        ],
         "operator": "not_eq"
     },
     {
@@ -6802,230 +9680,314 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "concept_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "constraint_conjunction",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "constraint_disjunction",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "gnu_asm_clobber_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "gnu_asm_goto_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "gnu_asm_input_operand",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "gnu_asm_input_operand_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "gnu_asm_output_operand",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "gnu_asm_output_operand_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "gnu_asm_qualifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "init_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "nested_namespace_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "pointer_type_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "preproc_elifdef",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "requirement_seq",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "simple_requirement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "subscript_argument_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "type_requirement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "character",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "raw_string_content",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "raw_string_delimiter",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "function_expression",
-        "metrics": ["complexity", "functions"],
+        "metrics": [
+            "complexity",
+            "functions"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "import_attribute",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "html_character_reference",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "html_comment",
-        "metrics": ["comment_lines", "real_lines_of_code"],
+        "metrics": [
+            "comment_lines",
+            "real_lines_of_code"
+        ],
         "type": "statement",
         "category": "comment",
-        "languages": ["js", "ts"]
+        "languages": [
+            "js",
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "const",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "adding_type_annotation",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["ts"]
+        "languages": [
+            "ts",
+            "tsx"
+        ]
     },
     {
         "expression": "seh_leave_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "seh_try_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "seh_except_clause",
-        "metrics": ["complexity"],
+        "metrics": [
+            "complexity"
+        ],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "seh_finally_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     },
     {
         "expression": "subscript_range_designator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": [
+            "cpp"
+        ]
     }
 ]

--- a/src/parser/helper/Language.ts
+++ b/src/parser/helper/Language.ts
@@ -21,6 +21,7 @@ export const enum Language {
     Kotlin,
     PHP,
     TypeScript,
+    TSX,
     Python,
     /**
      * For files with unknown file extension. Could be a source code file written in language(s) for which
@@ -48,6 +49,7 @@ export const languageToAbbreviation = new ConstantTwoWayMap<Language, string>(
         [Language.Kotlin, "kt"],
         [Language.PHP, "php"],
         [Language.TypeScript, "ts"],
+        [Language.TSX, "tsx"],
         [Language.Python, "py"],
         [Language.Unknown, "N/A"],
     ])
@@ -65,6 +67,7 @@ export const languageToGrammar = new Map([
     [Language.Kotlin, Kotlin],
     [Language.PHP, PHP],
     [Language.TypeScript, TypeScript.typescript],
+    [Language.TSX, TypeScript.tsx],
     [Language.Python, Python],
 ]);
 
@@ -87,6 +90,7 @@ export const fileExtensionToLanguage = new Map([
     ["kt", Language.Kotlin],
     ["php", Language.PHP],
     ["ts", Language.TypeScript],
+    ["tsx", Language.TSX],
     ["py", Language.Python],
 ]);
 

--- a/src/parser/helper/TreeParser.ts
+++ b/src/parser/helper/TreeParser.ts
@@ -36,13 +36,13 @@ export class TreeParser {
             // See https://flow.org/en/docs/usage/#toc-prepare-your-code-for-flow on how to identify them.
             // See https://github.com/tree-sitter/tree-sitter-typescript/tree/v0.20.5 on using the TSX-grammar
             // for flow-annotated files.
-            if (sourceCode.match(/^.*@flow/) !== null) {
+            if (sourceCode.match(/^(\/\*[\s*]*@flow)|(\/\/\s*@flow)/) !== null) {
                 grammarLanguage = Language.TSX;
             }
         }
 
         const parser = new Parser();
-        parser.setLanguage(languageToGrammar.get(parseFile.language));
+        parser.setLanguage(languageToGrammar.get(grammarLanguage));
 
         const tree = parser.parse(sourceCode);
 


### PR DESCRIPTION
Added tsx as supported file extension and language. Linked the language to the TSX-grammar that is part of tree-sitter-typescript. Also added support for identifying Flow-annotated JavaScript-files and parsing them via the TSX-grammar (see #9 for further details).

Just basic support without any testing yet.

Resolves #9