### PR TITLE
Performance: reduce amount of recursive and API calls for real lines of code

### DIFF
--- a/src/parser/metrics/RealLinesOfCode.ts
+++ b/src/parser/metrics/RealLinesOfCode.ts
@@ -40,15 +40,11 @@ export class RealLinesOfCode implements Metric {
         isComment: (node: Parser.SyntaxNode) => boolean,
         realLinesOfCode = new Set<number>()
     ) {
-        const currentNode = cursor.currentNode;
-        // This is not a comment syntax node, so assume it includes "real code".
+        const { currentNode } = cursor;
         if (!isComment(currentNode)) {
-            // Assume that first and last line of whatever kind of node this is, is a real code line.
-            // This assumption should hold for all kinds of block/composed statements in (hopefully) all languages.
             realLinesOfCode.add(currentNode.startPosition.row);
 
-            // This is a leaf node, so add further lines if this single token of actual code
-            // spans over multiple lines and is no line ending:
+            // This is a leaf node, so add further lines if it spans over multiple lines and is no line ending:
             if (currentNode.childCount === 0 && !"\r\n".includes(currentNode.type)) {
                 for (
                     let i = currentNode.startPosition.row + 1;
@@ -57,9 +53,7 @@ export class RealLinesOfCode implements Metric {
                 ) {
                     realLinesOfCode.add(i);
                 }
-            }
-            // Optimization: only go down the tree if we have not already covered all lines under this node:
-            else if (currentNode.endPosition.row > currentNode.startPosition.row) {
+            } else if (currentNode.endPosition.row > currentNode.startPosition.row) {
                 // Recurse, depth-first
                 if (cursor.gotoFirstChild()) {
                     this.walkTree(cursor, isComment, realLinesOfCode);


### PR DESCRIPTION
This checks now if there is the necessity to traverse further down the tree before doing so. It also stores the result of `cursor.currentNode` instead of calling this tree-sitter API function multiple times.

When applied on top of the performance improvements of #148, this reduces the time to parse the CodeCharta codebase from 1,4 seconds to 0,72 seconds (720 milliseconds), approximately minus 50%

Resolves #153