### PR TITLE
Support for the C programming language, support for C/C++ Enums and Unions, various Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ This is quite slow and can take up to one or two hours but can provide good resu
 -   Ruby
 -   Rust
 -   Bash (the binary logical operators -o for "or" and -a for "and" are currently not evaluated due to issues with tree-sitter-bash. For the same reason, the && and || operators are not evaluated if placed after the first heredoc delimiter. Default labels in Switch-statement are treated as regular case labels.)
--   C
-
-Note: to parse .h files as C instead of C++, use the command line option `parse-h-as-c` or `parse-some-h-as-c`.
+-   C (take a look at the CLI option [`parse-h-as-c`](#command-line-options-for-the-parse-command) or [`parse-some-h-as-c`](#command-line-options-for-the-parse-command) for parsing `.h` C headers as C)
 
 ### Supported File Metrics
 
@@ -90,19 +88,32 @@ The number of comment lines inside a file. Does count for any kind of comment (e
 **real_lines_of_code**<br>
 The number of lines inside a file that contain actual code of the programming language, not counting for comments, empty lines, etc.
 
-### Coupling Metrics (experimental)
+### Command line options for the `parse` command
 
-**Supported for C# and PHP**<br>
-Activate dependency analysis by passing `--parseDependencies`
+`--help`<br>
+Shows an overview over all options and their usage
 
--   Coupling Between Objects (CBO)
--   Incoming Dependencies
--   Outgoing Dependencies
--   Instability: Outgoing Dependencies / (Outgoing Dependencies + Incoming Dependencies)
+`--output-path`, `-o`<br>
+Specifies the location on which the .json-file with the results should be stored, e.g. `./metrics.json`. This is required.
 
-**Limitations:**<br>
+`--relative-paths`, `-r`<br>
+Write paths to the analyzed files in the output .json-file relative to the source directory instead of writing the absolute paths to the files. E.g. writes `src/package1/file1.java` instead of `/home/user.name/programming/project1/src/package1/file1.java` (works also for Windows-style paths).
 
--   Multiple, nested Namespace Declarations within one .cs file are not covered so far and are ignored during the calculation of coupling.
+`--exclusions`, `-e`<br>
+Excludes the specified folders from being scanned for files to be analyzed. Can be an arbitrarily nested subdirectory, so something like `--exclusions "folder1"` does exclude `src/package1/folder1`. Does exclude all files in the folder itself as well as in all subdirectories of the folder.
+
+`--parse-h-as-c`, `--hc`<br>
+Parse all files with the file extension `.h` as files written in the C programming language instead of C++. Defaults to C++, as the C++ grammar is mostly a superset of the C grammar.
+
+`--parse-some-h-as-c`, `--shc`<br>
+Parse all files inside the specified folders that have the file extension `.h` as files written in the C programming language instead of C++. Defaults to C++. Can be also used for file names, e.g. `--shc header-file.h`. Similar to `--exclusions`, the folder/file can lie in an arbitrary subdirectory and the option applies to all files in all subdirectories of the specified folder(s).
+
+`--compress`, `-c`<br>
+Compresses the output .json-file into an zip-archive.
+
+`--parse-dependencies`<br>
+EXPERIMENTAL - VERY SLOW AND NOT READY FOR PRODUCTIVE USE YET<br>
+Performs a dependency analysis and appends the results to the output .json-file (see [below](#experimental-coupling-metrics)).
 
 ### Updating tree-sitter grammars and adding support for more languages
 
@@ -117,6 +128,22 @@ Check out our contribution guidelines in the file [CONTRIBUTING.md](CONTRIBUTING
 There are additional outputs about the metric calculation process that can be enabled by setting the
 environment variable `NODE_DEBUG` to `metric-gardener`.
 
+### Experimental Coupling Metrics
+
+**EXPERIMENTAL - VERY SLOW AND NOT READY FOR PRODUCTIVE USE YET**
+
+**Supported for C# and PHP**<br>
+Activate dependency analysis by passing `--parseDependencies`
+
+-   Coupling Between Objects (CBO)
+-   Incoming Dependencies
+-   Outgoing Dependencies
+-   Instability: Outgoing Dependencies / (Outgoing Dependencies + Incoming Dependencies)
+
+**Limitations:**<br>
+
+-   Multiple, nested Namespace Declarations within one .cs file are not covered so far and are ignored during the calculation of coupling.
+
 ### TODOs
 
 Next Steps:
@@ -127,7 +154,6 @@ Next Steps:
 
 Performance Optimizations:
 
--   Mapped Expressions: Query expressions for current language only instead of brute force all available metric expressions
 -   Skip primitive types like (void, boolean, etc.) during accessor scan and usage candidates building
 -   Exclude System Namespaces like System in CSharp etc. (Configurable option would also be nice (e.g. exclude NameSpace _UnitTest_))
 -   Improve performance in Abstract Usage Collector (add candidates only if they can be found in previously retrieved fully qualified type names in other words the Namespace Collector).
@@ -145,7 +171,6 @@ Other TODOs and ideas:
 -   Performance & Duplicate Adds (see TODO comments)
 -   Export relationships as a graph file
 -   Write command to add new language and map expressions
--   Checkout sample project(s) per language and parse them as an automatically test
+-   Checkout sample project(s) per language and parse them as an automatic test
 -   ProgressBar
 -   Separate Infrastructure from Domain Code
--   Support more languages

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Counts expressions that branch the control flow, like if-statements, loops, swit
 The number of function declarations inside a file. Includes all kinds of functions, like constructors, lambda functions, member functions, abstract functions, constructors, init blocks, closures, etc.
 
 **classes**<br>
-<<<<<<< HEAD
 The number of class definitions inside a file, also counting for enums, interfaces, structs, unions, traits and records.
 
 <details><summary>Language specific details</summary>

--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ This is quite slow and can take up to one or two hours but can provide good resu
 
 **It is based on grammars from [tree-sitter](https://github.com/tree-sitter/tree-sitter).**
 
-### Main Issues with MetricGardener
-
-1.  It is not very well tested
-2.  Because of 1., there might be some issues for certain languages
-3.  The list of supported languages is still rather limited
-
 ### Usage
 
 #### Install required build tools:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Counts expressions that branch the control flow, like if-statements, loops, swit
 The number of function declarations inside a file. Includes all kinds of functions, like constructors, lambda functions, member functions, abstract functions, constructors, init blocks, closures, etc.
 
 **classes**<br>
-The number of class definitions inside a file, also counting for enums, interfaces, structs, traits, records and types.
+<<<<<<< HEAD
+The number of class definitions inside a file, also counting for enums, interfaces, structs, unions, traits and records.
 
 <details><summary>Language specific details</summary>
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ This is quite slow and can take up to one or two hours but can provide good resu
 -   Ruby
 -   Rust
 -   Bash (the binary logical operators -o for "or" and -a for "and" are currently not evaluated due to issues with tree-sitter-bash. For the same reason, the && and || operators are not evaluated if placed after the first heredoc delimiter. Default labels in Switch-statement are treated as regular case labels.)
+-   C
+
+Note: to parse .h files as C instead of C++, use the command line option `parse-h-as-c` or `parse-some-h-as-c`.
 
 ### Supported File Metrics
 

--- a/UPDATE_GRAMMARS.md
+++ b/UPDATE_GRAMMARS.md
@@ -2,7 +2,7 @@
 
 ## Updating grammars
 
-If you update the tree-sitter grammars installed as dependency of this project, you need to update the node types config file found under `./src/parser/config/nodeTypesConfig.json`.
+If you update the tree-sitter grammars installed as dependency of this project, you need to update the node types config file [nodeTypesConfig.json](src%2Fparser%2Fconfig%2FnodeTypesConfig.json).
 For this, reimport the grammars from all supported languages by running the import script:
 
 -   `npm run start -- import-grammars`
@@ -13,11 +13,11 @@ If there are new syntax node types included in the grammars (e.g. because of a n
 
 If you want to support a completely new programming language, you have to perform additional steps after installing the grammar as a dependency of this project and before running the import script:
 
--   Add the language, the file extension(s) of the source code files used by that language and an appropriate shortcut for that language to the enum and the maps inside `./src/helper/Languages.ts`.
--   You also have to add the path to the `node-types.json` of the tree-sitter grammar for that language to `./src/commands/ImportNodeTypes.ts`.
+-   Add the language, the file extension(s) of the source code files used by that language and an appropriate shortcut for that language to the enum and the maps inside [Language.ts](src%2Fparser%2Fhelper%2FLanguage.ts).
+-   You also have to add the path to the `node-types.json` of the tree-sitter grammar for that language to [ImportNodeTypes.ts](src%2Fcommands%2Fimport-grammars%2FImportNodeTypes.ts).
 -   After these steps, you can run the import script via `npm run start -- import-grammars` as mentioned above.
 -   You can now run metric-gardener on source code of that newly added language.
 
 **Note:**
 metric-gardener can only consider the syntax node types that are already included in one of the already supported language when calculating metrics.
-For a correct and stable support of the language, you probably have to add mappings from language-specific syntax node types to some metrics inside the `nodeTypesConfig.json`. If a syntax node type has a different semantic to a syntax node type of another language that is counted for a metric, you might have to use the `activated_for_languages` field of that syntax node type to not include it for your language. You should also add test cases for that language. Under some circumstances, you also have to include a special handling to the source code of the metric calculation to accommodate for some language features.
+For a correct and stable support of the language, you probably have to add mappings from language-specific syntax node types to some metrics inside the [nodeTypesConfig.json](src%2Fparser%2Fconfig%2FnodeTypesConfig.json). If a syntax node type has a different semantic to a syntax node type of another language that is counted for a metric, you might have to use the `activated_for_languages` field of that syntax node type to not include it for your language. You should also add test cases for that language. Under some circumstances, you also have to include a special handling to the source code of the metric calculation to accommodate for some language features.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "copyfiles": "2.4.1",
                 "tree-sitter": "0.20.6",
                 "tree-sitter-bash": "0.20.5",
+                "tree-sitter-c": "0.20.8",
                 "tree-sitter-c-sharp": "0.20.0",
                 "tree-sitter-cpp": "0.20.4",
                 "tree-sitter-go": "0.20.0",
@@ -10978,6 +10979,15 @@
                 "nan": "^2.18.0",
                 "prebuild-install": "^7.1.1",
                 "web-tree-sitter": "^0.20.8"
+            }
+        },
+        "node_modules/tree-sitter-c": {
+            "version": "0.20.8",
+            "resolved": "https://registry.npmjs.org/tree-sitter-c/-/tree-sitter-c-0.20.8.tgz",
+            "integrity": "sha512-1393KNfnj67sCpoUjvTa2w1zU1h/3WvZ3Oz/kQzpMQhOjJURTbHAiMguKbBHhveGcoiPWc19bObfybTOWxVorA==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "nan": "^2.18.0"
             }
         },
         "node_modules/tree-sitter-c-sharp": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "yargs": "17.7.2",
         "tree-sitter-ruby": "0.20.1",
         "tree-sitter-rust": "0.20.4",
+        "tree-sitter-c": "0.20.8",
         "zlib": "1.0.5"
     },
     "devDependencies": {

--- a/resources/c++/enums_and_unions.cpp
+++ b/resources/c++/enums_and_unions.cpp
@@ -1,21 +1,21 @@
 /*
  * Unscoped enums:
  */
-enum unscoped_enum { Kartoffel, Karotte, Kohlrabi, Krautsalat };
-enum unscoped_fixed_type_enum: int { Eins, Zwei, Drei };
+enum unscoped_enum { Potato, Carrot, Kohlrabi, Coleslaw };
+enum unscoped_fixed_type_enum: int { One, Two, Tree };
 // unscoped enums with unfixed type cannot be opaque/forward declared.
 enum unscoped_fixed_type_opaque_enum: int;
 
 /*
  * Scoped enums:
  */
-enum class scoped_class_enum { Kartoffel, Karotte, Kohlrabi, Krautsalat };
-enum class scoped_class_fixed_enum: int { Eins, Zwei, Drei };
+enum class scoped_class_enum { Potato, Carrot, Kohlrabi, Coleslaw };
+enum class scoped_class_fixed_enum: int { One, Two, Tree };
 enum class scoped_class_opaque_enum;
 enum class scoped_class_fixed_opaque_enum: int;
 
-enum struct scoped_struct_enum { Kartoffel, Karotte, Kohlrabi, Krautsalat };
-enum struct scoped_struct_fixed_enum: int { Eins, Zwei, Drei };
+enum struct scoped_struct_enum { Potato, Carrot, Kohlrabi, Coleslaw };
+enum struct scoped_struct_fixed_enum: int { One, Two, Tree };
 enum struct scoped_struct_opaque_enum;
 enum struct scoped_struct_fixed_opaque_enum: int;
 

--- a/resources/c++/enums_and_unions.cpp
+++ b/resources/c++/enums_and_unions.cpp
@@ -1,0 +1,61 @@
+
+enum unscoped_enum { Kartoffel, Karotte, Kohlrabi, Krautsalat };
+enum unscoped_fixed_type_enum: int { Eins, Zwei, Drei };
+// unfixed forward declaration not allowed by ISO C++ according to clang compiler.
+enum unscoped_fixed_type_opaque_enum: int;
+
+enum class scoped_class_enum { Kartoffel, Karotte, Kohlrabi, Krautsalat };
+enum class scoped_class_fixed_enum: int { Eins, Zwei, Drei };
+enum class scoped_class_opaque_enum;
+enum class scoped_class_fixed_opaque_enum: int;
+
+enum struct scoped_struct_enum { Kartoffel, Karotte, Kohlrabi, Krautsalat };
+enum struct scoped_struct_fixed_enum: int { Eins, Zwei, Drei };
+enum struct scoped_struct_opaque_enum;
+enum struct scoped_struct_fixed_opaque_enum: int;
+
+union an_union {
+    int i;
+    char c;
+};
+
+typedef union a_second_union {
+    int i;
+    char c;
+} the_second_union;
+
+union another_union {
+    int i;
+    char c;
+
+    int add(int j) {
+        return i + j;
+    }
+};
+
+struct struct_name {
+    int field1;
+    // Anonymous union:
+    union {
+        int one_field2;
+        char another_field2;
+    };
+};
+
+int main() {
+    // Anonymous union:
+    union {
+        int number;
+        const char* char_pointer;
+    };
+
+    // Anonymous enum:
+    enum { a, b, c, d };
+    // Anonymous fixed type enum:
+    enum: int { e, f, g, h };
+
+    enum unscoped_fixed_type_opaque_enum : int;
+
+    number = 5;
+    char_pointer = "Wuhuu!";
+}

--- a/resources/c++/enums_and_unions.cpp
+++ b/resources/c++/enums_and_unions.cpp
@@ -1,9 +1,14 @@
-
+/*
+ * Unscoped enums:
+ */
 enum unscoped_enum { Kartoffel, Karotte, Kohlrabi, Krautsalat };
 enum unscoped_fixed_type_enum: int { Eins, Zwei, Drei };
-// unfixed forward declaration not allowed by ISO C++ according to clang compiler.
+// unscoped enums with unfixed type cannot be opaque/forward declared.
 enum unscoped_fixed_type_opaque_enum: int;
 
+/*
+ * Scoped enums:
+ */
 enum class scoped_class_enum { Kartoffel, Karotte, Kohlrabi, Krautsalat };
 enum class scoped_class_fixed_enum: int { Eins, Zwei, Drei };
 enum class scoped_class_opaque_enum;
@@ -13,6 +18,9 @@ enum struct scoped_struct_enum { Kartoffel, Karotte, Kohlrabi, Krautsalat };
 enum struct scoped_struct_fixed_enum: int { Eins, Zwei, Drei };
 enum struct scoped_struct_opaque_enum;
 enum struct scoped_struct_fixed_opaque_enum: int;
+
+// Should not count, as it is just an alias definition not defining a new enum:
+typedef enum unscoped_enum Meals;
 
 union an_union {
     int i;

--- a/resources/c++/structs.hpp
+++ b/resources/c++/structs.hpp
@@ -1,15 +1,33 @@
 #ifndef STRUCTS_18734
 #define STRUCTS_18734
 
+// C-style structs with typedef:
+
 struct example_struct {
     int a;
     int b;
     int c;
 };
 
+typedef struct {
+    int first;
+    char* second;
+} example_typedef_struct;
+
+typedef struct struct_name {
+    char first;
+    char second;
+    char third;
+} typedef_name;
+
+typedef example_struct example_struct_alias;
+typedef int Custom_Number;
+
 struct derived_struct : public example_struct {
-    int d;
+    Custom_Number d;
 };
+
+// C++ class-like struct
 
 struct class_like_struct {
     /**

--- a/resources/c++/typedefs.h
+++ b/resources/c++/typedefs.h
@@ -3,8 +3,10 @@
 
 enum Food { Kartoffel, Sauerkraut, Bratwurst, Brezel, Bauernbrot };
 
-// New fixed-type enum introduced in C23.
-enum Food_C23: int { Pizza, Pasta, Schnitzel, Backfisch };
+// Scoped enum:
+enum struct Scoped_Enum { Pizza, Pasta, Schnitzel, Backfisch };
+// Opaque scoped enum:
+enum struct Scoped_Enum: int;
 
 // Should not count as struct, as it defines just an alias.
 typedef enum Food Food;
@@ -45,20 +47,28 @@ typedef union second_union {
 typedef union first_union number_union;
 
 /*
- * Forward declared struct/union. Declares the struct/union, but does not define it.
- * So we should not count it as struct/union to avoid counting one struct two times.
- * Forward-declared enums are not allowed in C.
+ * Forward declared struct/class/union. Declares the struct/class/union, but does not define it.
+ * So we should not count it as struct/class/union to avoid counting one struct two times.
+ * Scoped enums are not forward declared, but opaque enums which can be used as-is (see above).
  */
 struct forward_declared;
+class forward_declared_class;
 union forward_declared_union;
 
-typedef struct forward_declared alias_name; // Do not count type aliases as structs/unions.
+// Do not count type aliases as structs/classes/unions.
+typedef struct forward_declared alias_name;
+typedef class forward_declared_class;
 typedef union forward_declared_union union_alias_name;
 
-// Only works with C++
-// typedef forward_declared another_alias_name;
+// Only works with C++. Should also not be counted.
+typedef forward_declared another_alias_name;
+typedef forward_declared_class another_class_alias_name;
+typedef forward_declared_union another_union_alias_name;
 
-struct forward_declared { // Should only count a struct definition as a struct.
+// Should only count a struct/class/union definition as a struct/class/union, like the following:
+struct forward_declared {
+};
+class forward_declared_class {
 };
 union forward_declared_union {
 };

--- a/resources/c++/typedefs.h
+++ b/resources/c++/typedefs.h
@@ -1,15 +1,18 @@
-#ifndef C_EXAMPLE_HEADER_987678
-#define C_EXAMPLE_HEADER_987678
+#ifndef TYPEDEF_HEADER_87945
+#define TYPEDEF_HEADER_87945
 
 enum Food { Kartoffel, Sauerkraut, Bratwurst, Brezel, Bauernbrot };
 
 // Scoped enum:
 enum struct Scoped_Enum { Pizza, Pasta, Schnitzel, Backfisch };
 // Opaque scoped enum:
-enum struct Scoped_Enum: int;
+enum struct Scoped_Enum_2: int;
 
-// Should not count as struct, as it defines just an alias.
+// Should not count as enum, as it defines just an alias.
 typedef enum Food Food;
+// The following does not work:
+// typedef enum struct Scoped_Enum Scoped_Enum_Alias;
+typedef enum Scoped_Enum Scoped_Enum_Alias;
 
 struct not_easily_usable {
     int a;
@@ -57,7 +60,7 @@ union forward_declared_union;
 
 // Do not count type aliases as structs/classes/unions.
 typedef struct forward_declared alias_name;
-typedef class forward_declared_class;
+typedef class forward_declared_class class_alias_name;
 typedef union forward_declared_union union_alias_name;
 
 // Only works with C++. Should also not be counted.

--- a/resources/c++/typedefs.h
+++ b/resources/c++/typedefs.h
@@ -10,7 +10,7 @@ enum struct Scoped_Enum_2: int;
 
 // Should not count as enum, as it defines just an alias.
 typedef enum Food Food;
-// The following does not work:
+// The following is no valid C++ code and does not compile:
 // typedef enum struct Scoped_Enum Scoped_Enum_Alias;
 typedef enum Scoped_Enum Scoped_Enum_Alias;
 

--- a/resources/c++/typedefs.h
+++ b/resources/c++/typedefs.h
@@ -1,10 +1,10 @@
 #ifndef TYPEDEF_HEADER_87945
 #define TYPEDEF_HEADER_87945
 
-enum Food { Kartoffel, Sauerkraut, Bratwurst, Brezel, Bauernbrot };
+enum Food { Potato, Sauerkraut, Sausage, Pretzel, Bread };
 
 // Scoped enum:
-enum struct Scoped_Enum { Pizza, Pasta, Schnitzel, Backfisch };
+enum struct Scoped_Enum { Pizza, Pasta, Fish, Steak };
 // Opaque scoped enum:
 enum struct Scoped_Enum_2: int;
 

--- a/resources/c/c-example-code.c
+++ b/resources/c/c-example-code.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <string.h>
+
+st
+
+int main(int argc, char* argv[]) {
+    switch(argc) {
+        case 0:
+            puts("Cannot happen... something went REALLY wrong...");
+            break;
+        case 1:
+            printf("This program is named \"%s\"\n", argv[0]);
+        default:
+            for(int i = 0; i < argc; i++) {
+                printf("Command line argument no. %d is %s\n", i, argv[i]);
+            }
+    }
+
+    if(argc > 1 && strcmp(argv[1], "hello") == 0){
+        puts("Hello there!");
+    }
+
+    return 0;
+}

--- a/resources/c/c-example-code.c
+++ b/resources/c/c-example-code.c
@@ -1,7 +1,24 @@
 #include <stdio.h>
 #include <string.h>
+#include "c-example-header.h"
 
-st
+int visible_number = 5;
+
+int print_some_recipe(Food meal, int numberOfGuests) {
+    if(meal == Kartoffel){
+        puts("Recipe for potatoes");
+    } else if(meal == Sauerkraut) {
+        puts("How to make sauerkraut");
+    } else if(meal == Bratwurst) {
+        puts("Bratwurst recipe");
+    } else if(meal == Brezel || meal == Bauernbrot) {
+        puts("Baking guide");
+    } else {
+        puts("Unknown meal :(");
+        return -1;
+    }
+    return 0;
+}
 
 int main(int argc, char* argv[]) {
     switch(argc) {
@@ -19,6 +36,23 @@ int main(int argc, char* argv[]) {
     if(argc > 1 && strcmp(argv[1], "hello") == 0){
         puts("Hello there!");
     }
+
+    char* string_var = "Awesome text!";
+    char* c = string_var;
+
+    while(*c){
+        putchar(*c);
+        c++;
+    }
+    putchar('\n');
+
+    int f = 0;
+    do {
+        f++;
+    } while(f < 5);
+
+    printf("Value of variable f is %d\n", f);
+    print_some_recipe(Sauerkraut, f);
 
     return 0;
 }

--- a/resources/c/c-example-header.h
+++ b/resources/c/c-example-header.h
@@ -1,10 +1,10 @@
 #ifndef C_EXAMPLE_HEADER_987678
 #define C_EXAMPLE_HEADER_987678
 
-enum Food { Kartoffel, Sauerkraut, Bratwurst, Brezel, Bauernbrot };
+enum Food { Potato, Sauerkraut, Sausage, Pretzel, Bread };
 
 // New fixed-type enum introduced in C23.
-enum Food_C23: int { Pizza, Pasta, Schnitzel, Backfisch };
+enum Food_C23: int { Pizza, Pasta, Fish, Steak };
 
 // Should not count as struct, as it defines just an alias.
 typedef enum Food Food;

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,7 +27,13 @@ yargs(hideBin(process.argv))
                 .option("output-path", {
                     alias: "o",
                     type: "string",
-                    description: "Output file path",
+                    description: "Output file path (required)",
+                })
+                .option("relative-paths", {
+                    alias: "r",
+                    type: "boolean",
+                    description:
+                        "Write relative instead of absolute paths to the analyzed files in the output",
                 })
                 .option("exclusions", {
                     alias: "e",
@@ -48,12 +54,6 @@ yargs(hideBin(process.argv))
                         "For the specified folders/files (comma separated list), parse .h files as C instead of C++. " +
                         "Ignored if parse-h-as-c is set.",
                     default: "",
-                })
-                .option("print-relative-paths", {
-                    alias: "r",
-                    type: "boolean",
-                    description:
-                        "Use relative instead of absolute paths to the analyzed files in the output",
                 })
                 .option("compress", {
                     alias: "c",
@@ -87,7 +87,7 @@ async function parseSourceCode(argv) {
         parseAllHAsC: argv["parse-h-as-c"],
         parseSomeHAsC: argv["parse-some-h-as-c"],
         compress: argv["compress"],
-        relativePaths: argv["print-relative-paths"],
+        relativePaths: argv["relative-paths"],
     });
 
     console.time("Time to complete");

--- a/src/app.ts
+++ b/src/app.ts
@@ -65,7 +65,7 @@ yargs(hideBin(process.argv))
                     type: "boolean",
                     default: false,
                     description:
-                        "Flag to enable dependency parsing (dependencies will be appended to the output file)",
+                        "EXPERIMENTAL: flag to enable dependency parsing (dependencies will be appended to the output file)",
                 })
                 .demandOption(["sources-path", "output-path"]);
         },

--- a/src/app.ts
+++ b/src/app.ts
@@ -29,17 +29,31 @@ yargs(hideBin(process.argv))
                     type: "string",
                     description: "Output file path",
                 })
-                .option("parse-dependencies", {
-                    type: "boolean",
-                    default: false,
-                    description:
-                        "Flag to enable dependency parsing (dependencies will be appended to the output file)",
-                })
                 .option("exclusions", {
                     alias: "e",
                     type: "string",
                     description: "Exclude folders from scanning for files (comma separated list)",
                     default: "node_modules,.idea,dist,build,out,vendor",
+                })
+                .option("parse-h-as-c", {
+                    alias: "hc",
+                    type: "boolean",
+                    description: "Parse all .h files as C instead of C++ (defaults to C++)",
+                    default: false,
+                })
+                .option("parse-some-h-as-c", {
+                    alias: "shc",
+                    type: "string",
+                    description:
+                        "For the specified folders/files (comma separated list), parse .h files as C instead of C++. " +
+                        "Ignored if parse-h-as-c is set.",
+                    default: "",
+                })
+                .option("print-relative-paths", {
+                    alias: "r",
+                    type: "boolean",
+                    description:
+                        "Use relative instead of absolute paths to the analyzed files in the output",
                 })
                 .option("compress", {
                     alias: "c",
@@ -47,11 +61,11 @@ yargs(hideBin(process.argv))
                     description: "output .gz-zipped file",
                     default: false,
                 })
-                .option("print-relative-paths", {
-                    alias: "r",
+                .option("parse-dependencies", {
                     type: "boolean",
+                    default: false,
                     description:
-                        "Use relative instead of absolute paths to the analyzed files in the output",
+                        "Flag to enable dependency parsing (dependencies will be appended to the output file)",
                 })
                 .demandOption(["sources-path", "output-path"]);
         },
@@ -70,6 +84,8 @@ async function parseSourceCode(argv) {
         argv["output-path"],
         argv["parse-dependencies"],
         argv["exclusions"],
+        argv["parse-h-as-c"],
+        argv["parse-some-h-as-c"],
         argv["compress"],
         argv["print-relative-paths"],
     );

--- a/src/app.ts
+++ b/src/app.ts
@@ -79,16 +79,16 @@ yargs(hideBin(process.argv))
     .parseSync();
 
 async function parseSourceCode(argv) {
-    const configuration = new Configuration(
-        await fs.promises.realpath(argv["sources-path"]),
-        argv["output-path"],
-        argv["parse-dependencies"],
-        argv["exclusions"],
-        argv["parse-h-as-c"],
-        argv["parse-some-h-as-c"],
-        argv["compress"],
-        argv["print-relative-paths"],
-    );
+    const configuration = new Configuration({
+        sourcesPath: await fs.promises.realpath(argv["sources-path"]),
+        outputPath: argv["output-path"],
+        parseDependencies: argv["parse-dependencies"],
+        exclusions: argv["exclusions"],
+        parseAllHAsC: argv["parse-h-as-c"],
+        parseSomeHAsC: argv["parse-some-h-as-c"],
+        compress: argv["compress"],
+        relativePaths: argv["print-relative-paths"],
+    });
 
     console.time("Time to complete");
 

--- a/src/commands/DebugTraverseTree.ts
+++ b/src/commands/DebugTraverseTree.ts
@@ -1,0 +1,40 @@
+import Parser, { TreeCursor } from "tree-sitter";
+import { Language, languageToGrammar } from "../parser/helper/Language";
+import fs from "fs";
+
+if (require.main === module) {
+    traverseTree("./resources/c++/TEST.hpp", Language.CPlusPlus);
+}
+
+/**
+ * Traverses the syntax tree of a file depth-first and prints all encountered nodes.
+ * FOR DEBUGGING PURPOSES ONLY.
+ * @param filePath Path to the file.
+ * @param language Language to use for parsing.
+ */
+export function traverseTree(filePath: string, language: Language) {
+    const text: string = fs.readFileSync(filePath, { encoding: "utf8" });
+
+    const parser = new Parser();
+    parser.setLanguage(languageToGrammar.get(language));
+
+    const tree = parser.parse(text);
+
+    walkTree(tree.walk());
+}
+
+function walkTree(cursor: TreeCursor) {
+    const { currentNode } = cursor;
+    console.log(currentNode);
+
+    // Recurse, depth-first
+    if (cursor.gotoFirstChild()) {
+        walkTree(cursor);
+    }
+    if (cursor.gotoNextSibling()) {
+        walkTree(cursor);
+    } else {
+        // Completed searching this part of the tree, so go up now.
+        cursor.gotoParent();
+    }
+}

--- a/src/commands/import-grammars/ImportNodeTypes.ts
+++ b/src/commands/import-grammars/ImportNodeTypes.ts
@@ -26,6 +26,7 @@ export const languageAbbreviationToNodeTypeFiles = new Map([
     ["rb", "./node_modules/tree-sitter-ruby/src/node-types.json"],
     ["rs", "./node_modules/tree-sitter-rust/src/node-types.json"],
     ["sh", "./node_modules/tree-sitter-bash/src/node-types.json"],
+    ["c", "./node_modules/tree-sitter-c/src/node-types.json"],
 ]);
 
 export const pathToNodeTypesConfig = "./src/parser/config/nodeTypesConfig.json";

--- a/src/parser/Configuration.test.ts
+++ b/src/parser/Configuration.test.ts
@@ -1,101 +1,88 @@
-import { Configuration } from "./Configuration";
+import { getTestConfiguration } from "../../test/metric-end-results/TestHelper";
 
 describe("Configuration", () => {
     describe("the constructor", () => {
         it("should work correctly when multiple exclusions are given", () => {
-            const config = new Configuration(
-                "sourcesPath",
-                "output/path",
-                false,
-                "folder1 , folder2",
-                false,
-                "",
-                false,
-                false,
-            );
+            const config = getTestConfiguration("sourcesPath", { exclusions: "folder1 , folder2" });
 
             expect(config.exclusions.size).toBe(2);
             expect(config.exclusions.has("folder1")).toBe(true);
             expect(config.exclusions.has("folder2")).toBe(true);
 
-            expect(config.parseAllAsC).toBe(false);
-            expect(config.parseSomeAsC.size).toBe(0);
+            expect(config.parseAllHAsC).toBe(false);
+            expect(config.parseSomeHAsC.size).toBe(0);
         });
 
         it("should work correctly when one exclusion is given", () => {
-            const config = new Configuration(
-                "sourcesPath",
-                "output/path",
-                false,
-                "folder1",
-                false,
-                "",
-                false,
-                false,
-            );
+            const config = getTestConfiguration("sourcesPath", { exclusions: "folder1" });
 
             expect(config.exclusions.size).toBe(1);
             expect(config.exclusions.has("folder1")).toBe(true);
 
-            expect(config.parseAllAsC).toBe(false);
-            expect(config.parseSomeAsC.size).toBe(0);
+            expect(config.parseAllHAsC).toBe(false);
+            expect(config.parseSomeHAsC.size).toBe(0);
         });
 
         it("should work correctly when no exclusion is given", () => {
-            const config = new Configuration(
-                "sourcesPath",
-                "output/path",
-                false,
-                "",
-                false,
-                "",
-                false,
-                false,
-            );
+            const config = getTestConfiguration("sourcesPath");
 
             expect(config.exclusions.size).toBe(0);
 
-            expect(config.parseAllAsC).toBe(false);
-            expect(config.parseSomeAsC.size).toBe(0);
+            expect(config.parseAllHAsC).toBe(false);
+            expect(config.parseSomeHAsC.size).toBe(0);
         });
 
         it("should work correctly when some .h files should be parsed as C", () => {
-            const config = new Configuration(
-                "sourcesPath",
-                "output/path",
-                false,
-                "",
-                false,
-                "folder1, folder2",
-                false,
-                false,
-            );
+            const config = getTestConfiguration("sourcesPath", {
+                parseSomeHAsC: "folder1, folder2",
+            });
 
             expect(config.exclusions.size).toBe(0);
 
-            expect(config.parseAllAsC).toBe(false);
-            expect(config.parseSomeAsC.size).toBe(2);
-            expect(config.parseSomeAsC.has("folder1")).toBe(true);
-            expect(config.parseSomeAsC.has("folder2")).toBe(true);
+            expect(config.parseAllHAsC).toBe(false);
+            expect(config.parseSomeHAsC.size).toBe(2);
+            expect(config.parseSomeHAsC.has("folder1")).toBe(true);
+            expect(config.parseSomeHAsC.has("folder2")).toBe(true);
+        });
+
+        it("should work correctly when one .h file should be parsed as C", () => {
+            const config = getTestConfiguration("sourcesPath", { parseSomeHAsC: "header.h" });
+
+            expect(config.exclusions.size).toBe(0);
+
+            expect(config.parseAllHAsC).toBe(false);
+            expect(config.parseSomeHAsC.size).toBe(1);
+            expect(config.parseSomeHAsC.has("header.h")).toBe(true);
+            expect(config.parseSomeHAsC.has("folder1")).toBe(false);
         });
 
         it("should ignore when some .h files are specified to be parsed as C when all .h files should be parsed as C", () => {
-            const config = new Configuration(
-                "sourcesPath",
-                "output/path",
-                false,
-                "",
-                true,
-                "folder1, folder2",
-                false,
-                false,
-            );
+            const config = getTestConfiguration("sourcesPath", {
+                parseAllHAsC: true,
+                parseSomeHAsC: "folder1, folder2",
+            });
 
             expect(config.exclusions.size).toBe(0);
 
-            expect(config.parseAllAsC).toBe(true);
+            expect(config.parseAllHAsC).toBe(true);
             expect(config.exclusions.size).toBe(0);
-            expect(config.parseSomeAsC.size).toBe(0);
+            expect(config.parseSomeHAsC.size).toBe(0);
+        });
+
+        it("should work correctly when exclusions are given and some .h files should be parsed as C", () => {
+            const config = getTestConfiguration("sourcesPath", {
+                exclusions: "folder1 , folder2",
+                parseSomeHAsC: "folder3, folder4",
+            });
+
+            expect(config.exclusions.size).toBe(2);
+            expect(config.exclusions.has("folder1")).toBe(true);
+            expect(config.exclusions.has("folder2")).toBe(true);
+
+            expect(config.parseAllHAsC).toBe(false);
+            expect(config.parseSomeHAsC.size).toBe(2);
+            expect(config.parseSomeHAsC.has("folder3")).toBe(true);
+            expect(config.parseSomeHAsC.has("folder4")).toBe(true);
         });
     });
 });

--- a/src/parser/Configuration.test.ts
+++ b/src/parser/Configuration.test.ts
@@ -1,13 +1,15 @@
 import { Configuration } from "./Configuration";
 
 describe("Configuration", () => {
-    describe("initializes settings", () => {
-        it("when multiple exclusions are given", () => {
+    describe("the constructor", () => {
+        it("should work correctly when multiple exclusions are given", () => {
             const config = new Configuration(
                 "sourcesPath",
                 "output/path",
                 false,
                 "folder1 , folder2",
+                false,
+                "",
                 false,
                 false,
             );
@@ -15,19 +17,85 @@ describe("Configuration", () => {
             expect(config.exclusions.size).toBe(2);
             expect(config.exclusions.has("folder1")).toBe(true);
             expect(config.exclusions.has("folder2")).toBe(true);
+
+            expect(config.parseAllAsC).toBe(false);
+            expect(config.parseSomeAsC.size).toBe(0);
         });
-        it("when one exclusion is given", () => {
+
+        it("should work correctly when one exclusion is given", () => {
             const config = new Configuration(
                 "sourcesPath",
                 "output/path",
                 false,
                 "folder1",
                 false,
+                "",
+                false,
                 false,
             );
 
             expect(config.exclusions.size).toBe(1);
             expect(config.exclusions.has("folder1")).toBe(true);
+
+            expect(config.parseAllAsC).toBe(false);
+            expect(config.parseSomeAsC.size).toBe(0);
+        });
+
+        it("should work correctly when no exclusion is given", () => {
+            const config = new Configuration(
+                "sourcesPath",
+                "output/path",
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+            );
+
+            expect(config.exclusions.size).toBe(0);
+
+            expect(config.parseAllAsC).toBe(false);
+            expect(config.parseSomeAsC.size).toBe(0);
+        });
+
+        it("should work correctly when some .h files should be parsed as C", () => {
+            const config = new Configuration(
+                "sourcesPath",
+                "output/path",
+                false,
+                "",
+                false,
+                "folder1, folder2",
+                false,
+                false,
+            );
+
+            expect(config.exclusions.size).toBe(0);
+
+            expect(config.parseAllAsC).toBe(false);
+            expect(config.parseSomeAsC.size).toBe(2);
+            expect(config.parseSomeAsC.has("folder1")).toBe(true);
+            expect(config.parseSomeAsC.has("folder2")).toBe(true);
+        });
+
+        it("should ignore when some .h files are specified to be parsed as C when all .h files should be parsed as C", () => {
+            const config = new Configuration(
+                "sourcesPath",
+                "output/path",
+                false,
+                "",
+                true,
+                "folder1, folder2",
+                false,
+                false,
+            );
+
+            expect(config.exclusions.size).toBe(0);
+
+            expect(config.parseAllAsC).toBe(true);
+            expect(config.exclusions.size).toBe(0);
+            expect(config.parseSomeAsC.size).toBe(0);
         });
     });
 });

--- a/src/parser/Configuration.ts
+++ b/src/parser/Configuration.ts
@@ -82,7 +82,13 @@ export class Configuration {
         this.outputPath = outputPath;
         this.parseMetrics = true;
         this.parseDependencies = parseDependencies;
-        this.exclusions = new Set(exclusions.split(",").map((exclusion) => exclusion.trim()));
+
+        if (exclusions.length > 0) {
+            this.exclusions = new Set(exclusions.split(",").map((exclusion) => exclusion.trim()));
+        } else {
+            this.exclusions = new Set();
+        }
+
         this.parseAllAsC = parseAllAsC;
 
         if (!parseAllAsC && parseSomeAsC.length > 0) {

--- a/src/parser/Configuration.ts
+++ b/src/parser/Configuration.ts
@@ -28,6 +28,11 @@ export class Configuration {
     exclusions: Set<string>;
 
     /**
+     * Folders or file names for which .h files should be parsed as C instead of C++ files.
+     */
+    parseAsC: Set<string>;
+
+    /**
      * Whether to compress the output file with the calculated metrics in a zip archive.
      */
     compress: boolean;
@@ -50,17 +55,18 @@ export class Configuration {
      * @param outputPath Path where the output file with the calculated metrics should be stored.
      * @param parseDependencies Whether dependencies should be analyzed.
      * @param exclusions Folders to exclude from being searched for files to be parsed.
+     * @param parseAsC Folders or file names for which .h files should be parsed as C instead of C++ files.
      * @param compress Whether to compress the output file with the calculated metrics in a zip archive.
-     * @param relativePaths Whether to include the relative file paths or absolute paths
+     * @param relativePaths Whether to include the relative file paths or absolute paths of the analyzed files in the output.
      * @param enforceBackwardSlash Whether to replace all forward slashes in file paths by backward slashes in the output.
      * For platform-independent testing purposes only.
-     * of the analyzed files in the output.
      */
     constructor(
         sourcesPath: string,
         outputPath: string,
         parseDependencies: boolean,
         exclusions: string,
+        parseAsC: string,
         compress: boolean,
         relativePaths: boolean,
         enforceBackwardSlash = false,
@@ -70,6 +76,9 @@ export class Configuration {
         this.parseMetrics = true;
         this.parseDependencies = parseDependencies;
         this.exclusions = new Set(exclusions.split(",").map((exclusion) => exclusion.trim()));
+        this.parseAsC = new Set(
+            parseAsC.split(",").map((folderOrFileName) => folderOrFileName.trim()),
+        );
         this.compress = compress;
         this.relativePaths = relativePaths;
         this.enforceBackwardSlash = enforceBackwardSlash;

--- a/src/parser/Configuration.ts
+++ b/src/parser/Configuration.ts
@@ -5,48 +5,53 @@ export class Configuration {
     /**
      * Resolved, absolute path to the source files to be parsed.
      */
-    sourcesPath: string;
+    readonly sourcesPath: string;
 
     /**
      * Path where the output file with the calculated metrics should be stored.
      */
-    outputPath: string;
+    readonly outputPath: string;
 
     /**
      * Whether dependencies should be analyzed.
      */
-    parseMetrics: boolean;
+    readonly parseMetrics: boolean;
 
     /**
      * Folders to exclude from being searched for files to be parsed.
      */
-    parseDependencies: boolean;
+    readonly parseDependencies: boolean;
 
     /**
      * Folders to exclude from being searched for files to be parsed.
      */
-    exclusions: Set<string>;
+    readonly exclusions: Set<string>;
+
+    /**
+     * Whether to parse all .h files as C instead of C++.
+     */
+    readonly parseAllAsC: boolean;
 
     /**
      * Folders or file names for which .h files should be parsed as C instead of C++ files.
      */
-    parseAsC: Set<string>;
+    readonly parseSomeAsC: Set<string>;
 
     /**
      * Whether to compress the output file with the calculated metrics in a zip archive.
      */
-    compress: boolean;
+    readonly compress: boolean;
 
     /**
      * Whether to include the relative file paths or absolute paths of the analyzed files in the output.
      */
-    relativePaths: boolean;
+    readonly relativePaths: boolean;
 
     /**
      * Whether to replace all forward slashes in file paths by backward slashes in the output.
      * For platform-independent testing purposes only.
      */
-    enforceBackwardSlash: boolean;
+    readonly enforceBackwardSlash: boolean;
 
     /**
      * Constructs a new {@link Configuration} object by specifying the files to be parsed
@@ -55,7 +60,8 @@ export class Configuration {
      * @param outputPath Path where the output file with the calculated metrics should be stored.
      * @param parseDependencies Whether dependencies should be analyzed.
      * @param exclusions Folders to exclude from being searched for files to be parsed.
-     * @param parseAsC Folders or file names for which .h files should be parsed as C instead of C++ files.
+     * @param parseAllAsC Whether to parse all .h files as C instead of C++.
+     * @param parseSomeAsC Folders or file names for which .h files should be parsed as C instead of C++ files. Ignored if parseAllAsC is set.
      * @param compress Whether to compress the output file with the calculated metrics in a zip archive.
      * @param relativePaths Whether to include the relative file paths or absolute paths of the analyzed files in the output.
      * @param enforceBackwardSlash Whether to replace all forward slashes in file paths by backward slashes in the output.
@@ -66,7 +72,8 @@ export class Configuration {
         outputPath: string,
         parseDependencies: boolean,
         exclusions: string,
-        parseAsC: string,
+        parseAllAsC: boolean,
+        parseSomeAsC: string,
         compress: boolean,
         relativePaths: boolean,
         enforceBackwardSlash = false,
@@ -76,9 +83,16 @@ export class Configuration {
         this.parseMetrics = true;
         this.parseDependencies = parseDependencies;
         this.exclusions = new Set(exclusions.split(",").map((exclusion) => exclusion.trim()));
-        this.parseAsC = new Set(
-            parseAsC.split(",").map((folderOrFileName) => folderOrFileName.trim()),
-        );
+        this.parseAllAsC = parseAllAsC;
+
+        if (!parseAllAsC && parseSomeAsC.length > 0) {
+            this.parseSomeAsC = new Set(
+                parseSomeAsC.split(",").map((folderOrFileName) => folderOrFileName.trim()),
+            );
+        } else {
+            this.parseSomeAsC = new Set();
+        }
+
         this.compress = compress;
         this.relativePaths = relativePaths;
         this.enforceBackwardSlash = enforceBackwardSlash;

--- a/src/parser/Configuration.ts
+++ b/src/parser/Configuration.ts
@@ -1,4 +1,49 @@
 /**
+ * Parameters of the constructor of {@link Configuration}.
+ * Represents configuration options that can be provided by the user via command line arguments.
+ */
+export interface ConfigurationParams {
+    /**
+     * Path to the source files to be parsed.
+     */
+    sourcesPath: string;
+    /**
+     * Path where the output file with the calculated metrics should be stored.
+     */
+    outputPath: string;
+    /**
+     * Whether dependencies should be analyzed.
+     */
+    parseDependencies: boolean;
+    /**
+     * Folders to exclude from being searched for files to be parsed.
+     */
+    exclusions: string;
+    /**
+     * Whether to parse all .h files as C instead of C++.
+     */
+    parseAllHAsC: boolean;
+    /**
+     * Folders or file names for which .h files should be parsed as C instead of C++ files. Ignored if parseAllAsC is set.
+     */
+    parseSomeHAsC: string;
+    /**
+     * Whether to compress the output file with the calculated metrics in a zip archive.
+     */
+    compress: boolean;
+    /**
+     * Whether to include the relative file paths or absolute paths of the analyzed files in the output.
+     */
+    relativePaths: boolean;
+    /**
+     * Whether to replace all forward slashes in file paths by backward slashes
+     * in the output.
+     * FOR PLATFORM-INDEPENDENT TESTING PURPOSES ONLY: this option should not be exposed to the user.
+     */
+    enforceBackwardSlash?: boolean;
+}
+
+/**
  * Configures the files to be parsed and the metrics to be calculated.
  */
 export class Configuration {
@@ -30,12 +75,12 @@ export class Configuration {
     /**
      * Whether to parse all .h files as C instead of C++.
      */
-    readonly parseAllAsC: boolean;
+    readonly parseAllHAsC: boolean;
 
     /**
      * Folders or file names for which .h files should be parsed as C instead of C++ files.
      */
-    readonly parseSomeAsC: Set<string>;
+    readonly parseSomeHAsC: Set<string>;
 
     /**
      * Whether to compress the output file with the calculated metrics in a zip archive.
@@ -49,59 +94,41 @@ export class Configuration {
 
     /**
      * Whether to replace all forward slashes in file paths by backward slashes in the output.
-     * For platform-independent testing purposes only.
+     * FOR PLATFORM-INDEPENDENT TESTING PURPOSES ONLY: this option should not be exposed to the user.
      */
     readonly enforceBackwardSlash: boolean;
 
     /**
-     * Constructs a new {@link Configuration} object by specifying the files to be parsed
-     * and the metrics to be calculated.
-     * @param sourcesPath Path to the source files to be parsed.
-     * @param outputPath Path where the output file with the calculated metrics should be stored.
-     * @param parseDependencies Whether dependencies should be analyzed.
-     * @param exclusions Folders to exclude from being searched for files to be parsed.
-     * @param parseAllAsC Whether to parse all .h files as C instead of C++.
-     * @param parseSomeAsC Folders or file names for which .h files should be parsed as C instead of C++ files. Ignored if parseAllAsC is set.
-     * @param compress Whether to compress the output file with the calculated metrics in a zip archive.
-     * @param relativePaths Whether to include the relative file paths or absolute paths of the analyzed files in the output.
-     * @param enforceBackwardSlash Whether to replace all forward slashes in file paths by backward slashes in the output.
-     * For platform-independent testing purposes only.
+     * Constructs a new {@link Configuration} object by specifying the configuration options passed by the user
+     * as command line arguments.
+     * @param parameters {@link Parameters} object containing the configuration options.
      */
-    constructor(
-        sourcesPath: string,
-        outputPath: string,
-        parseDependencies: boolean,
-        exclusions: string,
-        parseAllAsC: boolean,
-        parseSomeAsC: string,
-        compress: boolean,
-        relativePaths: boolean,
-        enforceBackwardSlash = false,
-    ) {
-        this.sourcesPath = sourcesPath;
-        this.outputPath = outputPath;
+    constructor(parameters: ConfigurationParams) {
+        this.sourcesPath = parameters.sourcesPath;
+        this.outputPath = parameters.outputPath;
         this.parseMetrics = true;
-        this.parseDependencies = parseDependencies;
+        this.parseDependencies = parameters.parseDependencies;
 
-        if (exclusions.length > 0) {
-            this.exclusions = new Set(exclusions.split(",").map((exclusion) => exclusion.trim()));
-        } else {
-            this.exclusions = new Set();
-        }
+        this.exclusions = new Set(
+            parameters.exclusions.length > 0
+                ? parameters.exclusions.split(",").map((exclusion) => exclusion.trim())
+                : null,
+        );
 
-        this.parseAllAsC = parseAllAsC;
+        this.parseAllHAsC = parameters.parseAllHAsC;
 
-        if (!parseAllAsC && parseSomeAsC.length > 0) {
-            this.parseSomeAsC = new Set(
-                parseSomeAsC.split(",").map((folderOrFileName) => folderOrFileName.trim()),
-            );
-        } else {
-            this.parseSomeAsC = new Set();
-        }
+        this.parseSomeHAsC = new Set(
+            !parameters.parseAllHAsC && parameters.parseSomeHAsC.length > 0
+                ? parameters.parseSomeHAsC
+                      .split(",")
+                      .map((folderOrFileName) => folderOrFileName.trim())
+                : null,
+        );
 
-        this.compress = compress;
-        this.relativePaths = relativePaths;
-        this.enforceBackwardSlash = enforceBackwardSlash;
+        this.compress = parameters.compress;
+        this.relativePaths = parameters.relativePaths;
+        this.enforceBackwardSlash =
+            parameters.enforceBackwardSlash === undefined ? false : parameters.enforceBackwardSlash;
     }
 
     /**

--- a/src/parser/GenericParser.test.ts
+++ b/src/parser/GenericParser.test.ts
@@ -3,8 +3,8 @@ import { GenericParser } from "./GenericParser";
 import { getFileExtension } from "./helper/Helper";
 import * as HelperModule from "./helper/Helper";
 import { TreeParser } from "./helper/TreeParser";
-import { getParserConfiguration } from "../../test/metric-end-results/TestHelper";
-import { fileExtensionToLanguage, Language, languageToGrammar } from "./helper/Language";
+import { getParserTestConfiguration } from "../../test/metric-end-results/TestHelper";
+import { assumeLanguageFromFilePath, Language, languageToGrammar } from "./helper/Language";
 import Parser from "tree-sitter";
 import {
     SourceFile,
@@ -42,9 +42,8 @@ async function* mockedFindFilesAsyncError() {
 async function mockedTreeParserParse(filePath: string, config: Configuration) {
     const fileExtension = getFileExtension(filePath);
     return Promise.resolve({
-        fileExtension: fileExtension,
         filePath: filePath,
-        language: fileExtensionToLanguage.get(fileExtension),
+        language: assumeLanguageFromFilePath(fileExtension, config),
         tree: tree,
     });
 }
@@ -132,7 +131,7 @@ describe("GenericParser.calculateMetrics()", () => {
         ]);
         const couplingSpied = spyOnCouplingCalculatorNoOp();
 
-        const parser = new GenericParser(getParserConfiguration("clearly/invalid/path.cpp"));
+        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid/path.cpp"));
 
         /*
          * when:
@@ -160,7 +159,7 @@ describe("GenericParser.calculateMetrics()", () => {
             spyOnMetricCalculator().mockImplementation(mockedMetricsCalculator);
         const couplingSpied = spyOnCouplingCalculatorNoOp();
 
-        const parser = new GenericParser(getParserConfiguration("clearly/invalid"));
+        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid"));
 
         /*
          * when:
@@ -191,7 +190,7 @@ describe("GenericParser.calculateMetrics()", () => {
             spyOnMetricCalculator().mockImplementation(mockedMetricsCalculator);
         const couplingSpied = spyOnCouplingCalculatorNoOp();
 
-        const parser = new GenericParser(getParserConfiguration("clearly/invalid"));
+        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid"));
 
         /*
          * when:
@@ -223,7 +222,9 @@ describe("GenericParser.calculateMetrics()", () => {
             spyOnMetricCalculator().mockImplementation(mockedMetricsCalculator);
         const couplingSpied = spyOnCouplingCalculatorNoOp();
 
-        const parser = new GenericParser(getParserConfiguration("clearly/invalid/path.cpp", true));
+        const parser = new GenericParser(
+            getParserTestConfiguration("clearly/invalid/path.cpp", true),
+        );
         /*
          * when:
          */
@@ -247,7 +248,7 @@ describe("GenericParser.calculateMetrics()", () => {
 
         const errorSpy = spyOnConsoleErrorNoOp();
 
-        const parser = new GenericParser(getParserConfiguration("clearly/invalid/path.cpp"));
+        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid/path.cpp"));
         /*
          * when:
          */
@@ -276,7 +277,7 @@ describe("GenericParser.calculateMetrics()", () => {
 
         const errorSpy = spyOnConsoleErrorNoOp();
 
-        const parser = new GenericParser(getParserConfiguration("clearly/invalid/path.cpp"));
+        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid/path.cpp"));
 
         /*
          * when:
@@ -301,7 +302,7 @@ describe("GenericParser.calculateMetrics()", () => {
 
         spyOnMetricCalculator().mockImplementation(async (parsedFilePromise) => {
             const file = await parsedFilePromise;
-            if (file === null || file.fileExtension !== "cpp") {
+            if (file === null || getFileExtension(file.filePath) !== "cpp") {
                 throw new Error("I only accept cpp files!");
             }
             return [file.filePath, expectedFileMetricsMap];
@@ -309,7 +310,7 @@ describe("GenericParser.calculateMetrics()", () => {
 
         const errorSpy = spyOnConsoleErrorNoOp();
 
-        const parser = new GenericParser(getParserConfiguration("clearly/invalid"));
+        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid"));
 
         /*
          * when:
@@ -337,7 +338,7 @@ describe("GenericParser.calculateMetrics()", () => {
 
         const errorSpy = spyOnConsoleErrorNoOp();
 
-        const parser = new GenericParser(getParserConfiguration("clearly/invalid/path.cpp"));
+        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid/path.cpp"));
 
         /*
          * when:

--- a/src/parser/GenericParser.test.ts
+++ b/src/parser/GenericParser.test.ts
@@ -40,10 +40,9 @@ async function* mockedFindFilesAsyncError() {
 }
 
 async function mockedTreeParserParse(filePath: string, config: Configuration) {
-    const fileExtension = getFileExtension(filePath);
     return Promise.resolve({
         filePath: filePath,
-        language: assumeLanguageFromFilePath(fileExtension, config),
+        language: assumeLanguageFromFilePath(filePath, config),
         tree: tree,
     });
 }
@@ -223,7 +222,7 @@ describe("GenericParser.calculateMetrics()", () => {
         const couplingSpied = spyOnCouplingCalculatorNoOp();
 
         const parser = new GenericParser(
-            getParserTestConfiguration("clearly/invalid/path.cpp", true),
+            getParserTestConfiguration("clearly/invalid/path.cpp", false, true),
         );
         /*
          * when:

--- a/src/parser/GenericParser.test.ts
+++ b/src/parser/GenericParser.test.ts
@@ -3,7 +3,7 @@ import { GenericParser } from "./GenericParser";
 import { getFileExtension } from "./helper/Helper";
 import * as HelperModule from "./helper/Helper";
 import { TreeParser } from "./helper/TreeParser";
-import { getParserTestConfiguration } from "../../test/metric-end-results/TestHelper";
+import { getTestConfiguration } from "../../test/metric-end-results/TestHelper";
 import { assumeLanguageFromFilePath, Language, languageToGrammar } from "./helper/Language";
 import Parser from "tree-sitter";
 import {
@@ -130,7 +130,7 @@ describe("GenericParser.calculateMetrics()", () => {
         ]);
         const couplingSpied = spyOnCouplingCalculatorNoOp();
 
-        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid/path.cpp"));
+        const parser = new GenericParser(getTestConfiguration("clearly/invalid/path.cpp"));
 
         /*
          * when:
@@ -158,7 +158,7 @@ describe("GenericParser.calculateMetrics()", () => {
             spyOnMetricCalculator().mockImplementation(mockedMetricsCalculator);
         const couplingSpied = spyOnCouplingCalculatorNoOp();
 
-        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid"));
+        const parser = new GenericParser(getTestConfiguration("clearly/invalid"));
 
         /*
          * when:
@@ -189,7 +189,7 @@ describe("GenericParser.calculateMetrics()", () => {
             spyOnMetricCalculator().mockImplementation(mockedMetricsCalculator);
         const couplingSpied = spyOnCouplingCalculatorNoOp();
 
-        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid"));
+        const parser = new GenericParser(getTestConfiguration("clearly/invalid"));
 
         /*
          * when:
@@ -211,7 +211,7 @@ describe("GenericParser.calculateMetrics()", () => {
         expect(treeParserSpied).toHaveBeenCalledTimes(2);
     });
 
-    it("should call CouplingCalculator.calculateMetrics() when requested.", async () => {
+    it("should call CouplingCalculator.calculateMetrics() when parseDependencies is set.", async () => {
         /*
          * Given:
          */
@@ -222,7 +222,7 @@ describe("GenericParser.calculateMetrics()", () => {
         const couplingSpied = spyOnCouplingCalculatorNoOp();
 
         const parser = new GenericParser(
-            getParserTestConfiguration("clearly/invalid/path.cpp", false, true),
+            getTestConfiguration("clearly/invalid/path.cpp", { parseDependencies: true }),
         );
         /*
          * when:
@@ -247,7 +247,7 @@ describe("GenericParser.calculateMetrics()", () => {
 
         const errorSpy = spyOnConsoleErrorNoOp();
 
-        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid/path.cpp"));
+        const parser = new GenericParser(getTestConfiguration("clearly/invalid/path.cpp"));
         /*
          * when:
          */
@@ -276,7 +276,7 @@ describe("GenericParser.calculateMetrics()", () => {
 
         const errorSpy = spyOnConsoleErrorNoOp();
 
-        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid/path.cpp"));
+        const parser = new GenericParser(getTestConfiguration("clearly/invalid/path.cpp"));
 
         /*
          * when:
@@ -309,7 +309,7 @@ describe("GenericParser.calculateMetrics()", () => {
 
         const errorSpy = spyOnConsoleErrorNoOp();
 
-        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid"));
+        const parser = new GenericParser(getTestConfiguration("clearly/invalid"));
 
         /*
          * when:
@@ -337,7 +337,7 @@ describe("GenericParser.calculateMetrics()", () => {
 
         const errorSpy = spyOnConsoleErrorNoOp();
 
-        const parser = new GenericParser(getParserTestConfiguration("clearly/invalid/path.cpp"));
+        const parser = new GenericParser(getTestConfiguration("clearly/invalid/path.cpp"));
 
         /*
          * when:

--- a/src/parser/config/nodeTypesConfig.json
+++ b/src/parser/config/nodeTypesConfig.json
@@ -60,7 +60,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "cpp", "rs"]
+        "languages": ["cs", "go", "java", "cpp", "rs", "c"]
     },
     {
         "expression": "indexer_declaration",
@@ -158,7 +158,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "php", "ts", "cpp", "tsx", "rs"]
+        "languages": ["cs", "java", "js", "php", "ts", "cpp", "tsx", "rs", "c"]
     },
     {
         "expression": "await_expression",
@@ -179,7 +179,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"]
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"]
     },
     {
         "expression": "boolean_literal",
@@ -193,7 +193,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "php", "cpp"]
+        "languages": ["cs", "java", "php", "cpp", "c"]
     },
     {
         "expression": "character_literal",
@@ -221,7 +221,7 @@
         "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "php", "py", "cpp"]
+        "languages": ["cs", "php", "py", "cpp", "c"]
     },
     {
         "expression": "default_expression",
@@ -263,7 +263,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "kt", "ts", "py", "cpp", "tsx", "rb", "rs"]
+        "languages": ["cs", "go", "java", "js", "kt", "ts", "py", "cpp", "tsx", "rb", "rs", "c"]
     },
     {
         "expression": "implicit_array_creation_expression",
@@ -369,7 +369,21 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "kt", "php", "ts", "py", "cpp", "tsx", "rs", "sh"]
+        "languages": [
+            "cs",
+            "go",
+            "java",
+            "js",
+            "kt",
+            "php",
+            "ts",
+            "py",
+            "cpp",
+            "tsx",
+            "rs",
+            "sh",
+            "c"
+        ]
     },
     {
         "expression": "postfix_unary_expression",
@@ -446,7 +460,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "cpp", "kt", "rs"]
+        "languages": ["cs", "java", "cpp", "kt", "rs", "c"]
     },
     {
         "expression": "switch_expression",
@@ -509,7 +523,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx"]
+        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx", "c"]
     },
     {
         "expression": "checked_statement",
@@ -523,14 +537,14 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx"]
+        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx", "c"]
     },
     {
         "expression": "do_statement",
         "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "php", "ts", "cpp", "tsx"]
+        "languages": ["cs", "java", "js", "php", "ts", "cpp", "tsx", "c"]
     },
     {
         "expression": "empty_statement",
@@ -544,7 +558,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "php", "ts", "py", "cpp", "go", "tsx", "rs"]
+        "languages": ["cs", "java", "js", "php", "ts", "py", "cpp", "go", "tsx", "rs", "c"]
     },
     {
         "expression": "fixed_statement",
@@ -565,28 +579,28 @@
         "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "kt", "php", "ts", "py", "cpp", "tsx", "sh"]
+        "languages": ["cs", "go", "java", "js", "kt", "php", "ts", "py", "cpp", "tsx", "sh", "c"]
     },
     {
         "expression": "goto_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "php", "cpp"]
+        "languages": ["cs", "go", "php", "cpp", "c"]
     },
     {
         "expression": "if_statement",
         "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx", "sh"]
+        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx", "sh", "c"]
     },
     {
         "expression": "labeled_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "ts", "cpp", "tsx"]
+        "languages": ["cs", "go", "java", "js", "ts", "cpp", "tsx", "c"]
     },
     {
         "expression": "local_declaration_statement",
@@ -614,14 +628,14 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx"]
+        "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx", "c"]
     },
     {
         "expression": "switch_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "js", "php", "ts", "cpp", "tsx"]
+        "languages": ["cs", "js", "php", "ts", "cpp", "tsx", "c"]
     },
     {
         "expression": "throw_statement",
@@ -656,7 +670,7 @@
         "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "java", "js", "kt", "php", "ts", "py", "cpp", "tsx", "sh"]
+        "languages": ["cs", "java", "js", "kt", "php", "ts", "py", "cpp", "tsx", "sh", "c"]
     },
     {
         "expression": "yield_statement",
@@ -754,7 +768,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "java", "py", "cpp", "rb"]
+        "languages": ["cs", "go", "java", "py", "cpp", "rb", "c"]
     },
     {
         "expression": "array_rank_specifier",
@@ -782,7 +796,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "py", "cpp", "php", "rs"]
+        "languages": ["cs", "py", "cpp", "php", "rs", "c"]
     },
     {
         "expression": "attribute_argument",
@@ -824,7 +838,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "!="
     },
     {
@@ -832,7 +846,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "%"
     },
     {
@@ -840,7 +854,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "&"
     },
     {
@@ -848,7 +862,7 @@
         "metrics": ["complexity"],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "&&"
     },
     {
@@ -856,7 +870,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "*"
     },
     {
@@ -864,7 +878,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "+"
     },
     {
@@ -872,7 +886,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "-"
     },
     {
@@ -880,7 +894,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "/"
     },
     {
@@ -888,7 +902,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "<"
     },
     {
@@ -896,7 +910,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "<<"
     },
     {
@@ -904,7 +918,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "<="
     },
     {
@@ -912,7 +926,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "=="
     },
     {
@@ -920,7 +934,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": ">"
     },
     {
@@ -928,7 +942,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": ">="
     },
     {
@@ -936,7 +950,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": ">>"
     },
     {
@@ -952,7 +966,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "^"
     },
     {
@@ -960,7 +974,7 @@
         "metrics": [],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "|"
     },
     {
@@ -968,7 +982,7 @@
         "metrics": ["complexity"],
         "type": "statement",
         "category": "binary_expression",
-        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh"],
+        "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
         "operator": "||"
     },
     {
@@ -1060,7 +1074,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "php", "cpp", "rs"]
+        "languages": ["cs", "php", "cpp", "rs", "c"]
     },
     {
         "expression": "declaration_pattern",
@@ -1291,7 +1305,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "cpp"]
+        "languages": ["cs", "go", "cpp", "c"]
     },
     {
         "expression": "parameter_modifier",
@@ -1529,7 +1543,7 @@
         "metrics": ["comment_lines", "real_lines_of_code"],
         "type": "statement",
         "category": "comment",
-        "languages": ["cs", "go", "js", "php", "ts", "py", "cpp", "tsx", "rb", "sh"]
+        "languages": ["cs", "go", "js", "php", "ts", "py", "cpp", "tsx", "rb", "sh", "c"]
     },
     {
         "expression": "discard",
@@ -1543,14 +1557,14 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cs", "go", "js", "ts", "py", "cpp", "java", "php", "tsx", "rb", "rs"]
+        "languages": ["cs", "go", "js", "ts", "py", "cpp", "java", "php", "tsx", "rb", "rs", "c"]
     },
     {
         "expression": "false",
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["go", "java", "js", "ts", "py", "cpp", "tsx", "rb"]
+        "languages": ["go", "java", "js", "ts", "py", "cpp", "tsx", "rb", "c"]
     },
     {
         "expression": "module",
@@ -1579,7 +1593,7 @@
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["go", "java", "js", "ts", "py", "cpp", "tsx", "rb"]
+        "languages": ["go", "java", "js", "ts", "py", "cpp", "tsx", "rb", "c"]
     },
     {
         "expression": "type",
@@ -1614,7 +1628,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "js", "kt", "ts", "cpp", "tsx", "rs"]
+        "languages": ["go", "js", "kt", "ts", "cpp", "tsx", "rs", "c"]
     },
     {
         "expression": "composite_literal",
@@ -1719,7 +1733,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "java", "js", "ts", "cpp", "tsx", "rs", "sh"]
+        "languages": ["go", "java", "js", "ts", "cpp", "tsx", "rs", "sh", "c"]
     },
     {
         "expression": "_simple_statement",
@@ -1824,7 +1838,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "java", "kt", "ts", "cpp", "tsx", "rs"]
+        "languages": ["go", "java", "kt", "ts", "cpp", "tsx", "rs", "c"]
     },
     {
         "expression": "const_declaration",
@@ -1951,7 +1965,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "cpp", "rs"]
+        "languages": ["go", "cpp", "rs", "c"]
     },
     {
         "expression": "for_clause",
@@ -2028,7 +2042,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["go", "cpp"]
+        "languages": ["go", "cpp", "c"]
     },
     {
         "expression": "range_clause",
@@ -2105,7 +2119,7 @@
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["go", "cpp", "rs"]
+        "languages": ["go", "cpp", "rs", "c"]
     },
     {
         "expression": "import",
@@ -2231,7 +2245,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "js", "ts", "cpp", "tsx"]
+        "languages": ["java", "js", "ts", "cpp", "tsx", "c"]
     },
     {
         "expression": "annotation_type_declaration",
@@ -2280,7 +2294,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["java", "js", "php", "ts", "cpp", "tsx"]
+        "languages": ["java", "js", "php", "ts", "cpp", "tsx", "c"]
     },
     {
         "expression": "array_access",
@@ -2799,7 +2813,7 @@
         "metrics": [],
         "type": "keyword",
         "category": "",
-        "languages": ["js", "php", "ts", "cpp", "tsx"]
+        "languages": ["js", "php", "ts", "cpp", "tsx", "c"]
     },
     {
         "expression": "number",
@@ -2834,7 +2848,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "php", "ts", "cpp", "tsx"]
+        "languages": ["js", "php", "ts", "cpp", "tsx", "c"]
     },
     {
         "expression": "template_string",
@@ -2972,7 +2986,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "php", "ts", "py", "cpp", "tsx", "rs", "sh"]
+        "languages": ["js", "php", "ts", "py", "cpp", "tsx", "rs", "sh", "c"]
     },
     {
         "expression": "export_clause",
@@ -3182,7 +3196,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["js", "ts", "cpp", "tsx"]
+        "languages": ["js", "ts", "cpp", "tsx", "c"]
     },
     {
         "expression": "additive_expression",
@@ -3966,7 +3980,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php", "cpp", "sh"]
+        "languages": ["php", "cpp", "sh", "c"]
     },
     {
         "expression": "declare_statement",
@@ -3995,7 +4009,7 @@
         "type": "statement",
         "category": "",
         "activated_for_languages": ["php", "py", "sh"],
-        "languages": ["php", "py", "cpp", "sh"]
+        "languages": ["php", "py", "cpp", "sh", "c"]
     },
     {
         "expression": "function_static_declaration",
@@ -4058,7 +4072,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php", "cpp", "rs"]
+        "languages": ["php", "cpp", "rs", "c"]
     },
     {
         "expression": "anonymous_function_use_clause",
@@ -4134,8 +4148,8 @@
         "metrics": ["complexity"],
         "type": "statement",
         "category": "case_label",
-        "activated_for_languages": ["php", "cpp"],
-        "languages": ["php", "cpp", "sh"]
+        "activated_for_languages": ["php", "cpp", "c"],
+        "languages": ["php", "cpp", "sh", "c"]
     },
     {
         "expression": "cast_type",
@@ -4331,7 +4345,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["php", "cpp", "rs"]
+        "languages": ["php", "cpp", "rs", "c"]
     },
     {
         "expression": "variadic_unpacking",
@@ -4843,7 +4857,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py", "cpp"]
+        "languages": ["py", "cpp", "c"]
     },
     {
         "expression": "dictionary",
@@ -5074,28 +5088,28 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "abstract_function_declarator",
         "metrics": ["functions", "complexity"],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "abstract_parenthesized_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "abstract_pointer_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "abstract_reference_declarator",
@@ -5109,14 +5123,14 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "attributed_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "destructor_name",
@@ -5130,7 +5144,7 @@
         "metrics": ["functions", "complexity"],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "operator_name",
@@ -5144,14 +5158,14 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "pointer_declarator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "qualified_identifier",
@@ -5186,7 +5200,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp", "rs"]
+        "languages": ["cpp", "rs", "c"]
     },
     {
         "expression": "co_await_expression",
@@ -5200,7 +5214,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "delete_expression",
@@ -5214,14 +5228,14 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp", "rs"]
+        "languages": ["cpp", "rs", "c"]
     },
     {
         "expression": "number_literal",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "parameter_pack_expansion",
@@ -5235,14 +5249,14 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "sizeof_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "user_defined_literal",
@@ -5312,21 +5326,21 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "sized_type_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "struct_specifier",
         "metrics": ["classes"],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "template_type",
@@ -5340,7 +5354,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "access_specifier",
@@ -5361,21 +5375,21 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "attribute_specifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "attributed_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "base_class_clause",
@@ -5389,14 +5403,14 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "comma_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "condition_clause",
@@ -5431,14 +5445,14 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "enumerator_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "explicit_function_specifier",
@@ -5452,7 +5466,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "field_initializer",
@@ -5480,21 +5494,21 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "initializer_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "initializer_pair",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "lambda_capture_specifier",
@@ -5515,42 +5529,42 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "ms_based_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "ms_call_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "ms_declspec_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "ms_pointer_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "ms_unaligned_ptr_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "namespace_alias_definition",
@@ -5599,70 +5613,70 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "preproc_def",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "preproc_defined",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "preproc_elif",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "preproc_else",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "preproc_function_def",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "preproc_if",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "preproc_ifdef",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "preproc_include",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "preproc_params",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "ref_qualifier",
@@ -5683,14 +5697,14 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "subscript_designator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "template_argument_list",
@@ -5746,21 +5760,21 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "type_definition",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "type_descriptor",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "type_parameter_declaration",
@@ -5774,7 +5788,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "using_declaration",
@@ -5816,21 +5830,21 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "ms_signed_ptr_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "ms_unsigned_ptr_modifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "namespace_identifier",
@@ -5844,21 +5858,21 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "preproc_directive",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "system_lib_string",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "record_struct_declaration",
@@ -6670,7 +6684,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["py", "cpp", "rb", "sh"]
+        "languages": ["py", "cpp", "rb", "sh", "c"]
     },
     {
         "expression": "union_pattern",
@@ -6712,7 +6726,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "fold_expression",
@@ -6726,21 +6740,21 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "gnu_asm_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "offsetof_expression",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "requires_clause",
@@ -6827,49 +6841,49 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "gnu_asm_goto_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "gnu_asm_input_operand",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "gnu_asm_input_operand_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "gnu_asm_output_operand",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "gnu_asm_output_operand_list",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "gnu_asm_qualifier",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "init_statement",
@@ -6897,7 +6911,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "requirement_seq",
@@ -6932,7 +6946,7 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp", "rb"]
+        "languages": ["cpp", "rb", "c"]
     },
     {
         "expression": "raw_string_content",
@@ -6995,35 +7009,35 @@
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "seh_try_statement",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "seh_except_clause",
         "metrics": ["complexity"],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "seh_finally_clause",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "subscript_range_designator",
         "metrics": [],
         "type": "statement",
         "category": "",
-        "languages": ["cpp"]
+        "languages": ["cpp", "c"]
     },
     {
         "expression": "error_suppression_expression",
@@ -8811,5 +8825,12 @@
         "type": "statement",
         "category": "",
         "languages": ["sh"]
+    },
+    {
+        "expression": "macro_type_specifier",
+        "metrics": [],
+        "type": "statement",
+        "category": "",
+        "languages": ["c"]
     }
 ]

--- a/src/parser/config/nodeTypesConfig.json
+++ b/src/parser/config/nodeTypesConfig.json
@@ -5323,7 +5323,7 @@
     },
     {
         "expression": "enum_specifier",
-        "metrics": [],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
         "languages": ["cpp", "c"]
@@ -5351,7 +5351,7 @@
     },
     {
         "expression": "union_specifier",
-        "metrics": [],
+        "metrics": ["classes"],
         "type": "statement",
         "category": "",
         "languages": ["cpp", "c"]

--- a/src/parser/config/nodeTypesConfig.json
+++ b/src/parser/config/nodeTypesConfig.json
@@ -5302,7 +5302,7 @@
     },
     {
         "expression": "class_specifier",
-        "metrics": ["classes"],
+        "metrics": [],
         "type": "statement",
         "category": "",
         "languages": ["cpp"]
@@ -5323,7 +5323,7 @@
     },
     {
         "expression": "enum_specifier",
-        "metrics": ["classes"],
+        "metrics": [],
         "type": "statement",
         "category": "",
         "languages": ["cpp", "c"]
@@ -5337,7 +5337,7 @@
     },
     {
         "expression": "struct_specifier",
-        "metrics": ["classes"],
+        "metrics": [],
         "type": "statement",
         "category": "",
         "languages": ["cpp", "c"]
@@ -5351,7 +5351,7 @@
     },
     {
         "expression": "union_specifier",
-        "metrics": ["classes"],
+        "metrics": [],
         "type": "statement",
         "category": "",
         "languages": ["cpp", "c"]

--- a/src/parser/helper/Helper.test.ts
+++ b/src/parser/helper/Helper.test.ts
@@ -1,139 +1,92 @@
-import { getParserTestConfiguration } from "../../../test/metric-end-results/TestHelper";
+import { getTestConfiguration } from "../../../test/metric-end-results/TestHelper";
 import { formatPrintPath } from "./Helper";
-import { Configuration } from "../Configuration";
 import path from "path";
 
 describe("Helper.ts", () => {
     describe("formatPrintPath(...)", () => {
         it("should change nothing when the config does not say otherwise", () => {
             const filePath = "/some/path/for/the/test.extension";
-            const config = getParserTestConfiguration("/some/path");
+            const config = getTestConfiguration("/some/path");
 
             expect(formatPrintPath(filePath, config, path.posix)).toEqual(filePath);
         });
 
-        it("should replace forward slashes when configured", () => {
+        it("should replace forward slashes when enforceBackwardSlash is set", () => {
             const filePath = "/some/path/for/the/test.extension";
-            const config = new Configuration(
-                "/some/path",
-                "invalid/output/path",
-                false,
-                "",
-                false,
-                "",
-                false,
-                false,
-                true,
-            );
+            const config = getTestConfiguration("/some/path", { enforceBackwardSlash: true });
 
             expect(formatPrintPath(filePath, config, path.posix)).toEqual(
                 "\\some\\path\\for\\the\\test.extension",
             );
         });
 
-        it("should not replace backward slashes", () => {
+        it("should not replace backward slashes when enforceBackwardSlash is set", () => {
             const filePath = "C:\\Users\\user\\documents\\code\\file.extension";
-            const config = new Configuration(
-                "C:\\Users\\user\\documents\\code",
-                "invalid/output/path",
-                false,
-                "",
-                false,
-                "",
-                false,
-                false,
-                true,
-            );
+            const config = getTestConfiguration("C:\\Users\\user\\documents\\code", {
+                enforceBackwardSlash: true,
+            });
 
             expect(formatPrintPath(filePath, config, path.win32)).toEqual(filePath);
         });
 
-        it("should create UNIX-style relative paths when configured", () => {
+        it("should create UNIX-style relative paths when relativePaths is set", () => {
             const filePath = "/some/path/for/the/test.extension";
-            const config = new Configuration(
-                "/some/path",
-                "invalid/output/path",
-                false,
-                "",
-                false,
-                "",
-                false,
-                true,
-                false,
-            );
+            const config = getTestConfiguration("/some/path", { relativePaths: true });
 
             expect(formatPrintPath(filePath, config, path.posix)).toEqual("for/the/test.extension");
         });
 
-        it("should create DOS-style relative paths when configured", () => {
+        it("should create DOS-style relative paths when relativePaths is set", () => {
             const filePath = "C:\\Users\\user\\documents\\code\\more-code\\file.extension";
-            const config = new Configuration(
-                "C:\\Users\\user\\documents\\code",
-                "invalid/output/path",
-                false,
-                "",
-                false,
-                "",
-                false,
-                true,
-                false,
-            );
+            const config = getTestConfiguration("C:\\Users\\user\\documents\\code", {
+                relativePaths: true,
+            });
 
             expect(formatPrintPath(filePath, config, path.win32)).toEqual(
                 "more-code\\file.extension",
             );
         });
 
-        it("should return the file name if the file path equals the sources path (UNIX-style)", () => {
+        it("should return the file name if the file path equals the sources path when relativePaths is set (UNIX-style)", () => {
             const filePath = "/some/path/for/the/test.extension";
-            const config = new Configuration(
-                "/some/path/for/the/test.extension",
-                "invalid/output/path",
-                false,
-                "",
-                false,
-                "",
-                false,
-                true,
-                false,
-            );
+            const config = getTestConfiguration("/some/path/for/the/test.extension", {
+                relativePaths: true,
+            });
 
             expect(formatPrintPath(filePath, config, path.posix)).toEqual("test.extension");
         });
 
-        it("should return the file name if the file path equals the sources path (DOS-style)", () => {
+        it("should return the file name if the file path equals the sources path when relativePaths is set (DOS-style)", () => {
             const filePath = "C:\\Users\\user\\documents\\code\\more-code\\file.extension";
-            const config = new Configuration(
+            const config = getTestConfiguration(
                 "C:\\Users\\user\\documents\\code\\more-code\\file.extension",
-                "invalid/output/path",
-                false,
-                "",
-                false,
-                "",
-                false,
-                true,
-                false,
+                { relativePaths: true },
             );
 
             expect(formatPrintPath(filePath, config, path.win32)).toEqual("file.extension");
         });
 
-        it("should both create relative paths and replace forward slashes when configured", () => {
+        it("should both create relative paths and replace forward slashes in an UNIX-style path when both relativePaths and enforceBackwardSlash are set", () => {
             const filePath = "/some/path/for/the/test.extension";
-            const config = new Configuration(
-                "/some/path",
-                "invalid/output/path",
-                false,
-                "",
-                false,
-                "",
-                false,
-                true,
-                true,
-            );
+            const config = getTestConfiguration("/some/path", {
+                relativePaths: true,
+                enforceBackwardSlash: true,
+            });
 
             expect(formatPrintPath(filePath, config, path.posix)).toEqual(
                 "for\\the\\test.extension",
+            );
+        });
+
+        it("should only create relative paths for a DOS-style path when both relativePaths and enforceBackwardSlash are set", () => {
+            const filePath = "C:\\Users\\user\\documents\\code\\more-code\\file.extension";
+            const config = getTestConfiguration("C:\\Users\\user\\documents\\code", {
+                relativePaths: true,
+                enforceBackwardSlash: true,
+            });
+
+            expect(formatPrintPath(filePath, config, path.win32)).toEqual(
+                "more-code\\file.extension",
             );
         });
     });

--- a/src/parser/helper/Helper.test.ts
+++ b/src/parser/helper/Helper.test.ts
@@ -1,0 +1,140 @@
+import { getParserTestConfiguration } from "../../../test/metric-end-results/TestHelper";
+import { formatPrintPath } from "./Helper";
+import { Configuration } from "../Configuration";
+import path from "path";
+
+describe("Helper.ts", () => {
+    describe("formatPrintPath(...)", () => {
+        it("should change nothing when the config does not say otherwise", () => {
+            const filePath = "/some/path/for/the/test.extension";
+            const config = getParserTestConfiguration("/some/path");
+
+            expect(formatPrintPath(filePath, config, path.posix)).toEqual(filePath);
+        });
+
+        it("should replace forward slashes when configured", () => {
+            const filePath = "/some/path/for/the/test.extension";
+            const config = new Configuration(
+                "/some/path",
+                "invalid/output/path",
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                true,
+            );
+
+            expect(formatPrintPath(filePath, config, path.posix)).toEqual(
+                "\\some\\path\\for\\the\\test.extension",
+            );
+        });
+
+        it("should not replace backward slashes", () => {
+            const filePath = "C:\\Users\\user\\documents\\code\\file.extension";
+            const config = new Configuration(
+                "C:\\Users\\user\\documents\\code",
+                "invalid/output/path",
+                false,
+                "",
+                false,
+                "",
+                false,
+                false,
+                true,
+            );
+
+            expect(formatPrintPath(filePath, config, path.win32)).toEqual(filePath);
+        });
+
+        it("should create UNIX-style relative paths when configured", () => {
+            const filePath = "/some/path/for/the/test.extension";
+            const config = new Configuration(
+                "/some/path",
+                "invalid/output/path",
+                false,
+                "",
+                false,
+                "",
+                false,
+                true,
+                false,
+            );
+
+            expect(formatPrintPath(filePath, config, path.posix)).toEqual("for/the/test.extension");
+        });
+
+        it("should create DOS-style relative paths when configured", () => {
+            const filePath = "C:\\Users\\user\\documents\\code\\more-code\\file.extension";
+            const config = new Configuration(
+                "C:\\Users\\user\\documents\\code",
+                "invalid/output/path",
+                false,
+                "",
+                false,
+                "",
+                false,
+                true,
+                false,
+            );
+
+            expect(formatPrintPath(filePath, config, path.win32)).toEqual(
+                "more-code\\file.extension",
+            );
+        });
+
+        it("should return the file name if the file path equals the sources path (UNIX-style)", () => {
+            const filePath = "/some/path/for/the/test.extension";
+            const config = new Configuration(
+                "/some/path/for/the/test.extension",
+                "invalid/output/path",
+                false,
+                "",
+                false,
+                "",
+                false,
+                true,
+                false,
+            );
+
+            expect(formatPrintPath(filePath, config, path.posix)).toEqual("test.extension");
+        });
+
+        it("should return the file name if the file path equals the sources path (DOS-style)", () => {
+            const filePath = "C:\\Users\\user\\documents\\code\\more-code\\file.extension";
+            const config = new Configuration(
+                "C:\\Users\\user\\documents\\code\\more-code\\file.extension",
+                "invalid/output/path",
+                false,
+                "",
+                false,
+                "",
+                false,
+                true,
+                false,
+            );
+
+            expect(formatPrintPath(filePath, config, path.win32)).toEqual("file.extension");
+        });
+
+        it("should both create relative paths and replace forward slashes when configured", () => {
+            const filePath = "/some/path/for/the/test.extension";
+            const config = new Configuration(
+                "/some/path",
+                "invalid/output/path",
+                false,
+                "",
+                false,
+                "",
+                false,
+                true,
+                true,
+            );
+
+            expect(formatPrintPath(filePath, config, path.posix)).toEqual(
+                "for\\the\\test.extension",
+            );
+        });
+    });
+});

--- a/src/parser/helper/Helper.ts
+++ b/src/parser/helper/Helper.ts
@@ -77,13 +77,13 @@ export function replaceForwardWithBackwardSlashes(path: string) {
 export function formatPrintPath(filePath: string, config: Configuration): string {
     let result = filePath;
     if (config.relativePaths) {
-        // Returns the file path relative to the specified base directory, or the name of the file,
+        // Return the file path relative to the specified base directory, or the name of the file,
         // if the base path points to this single file.
         result = path.relative(config.sourcesPath, filePath);
-        if (config.sourcesPath.length === 0) {
+        if (result.length === 0) {
             // The path specified by the user points to a single file,
             // so return the name of the file as path to print.
-            config.sourcesPath = path.basename(filePath);
+            result = path.basename(filePath);
         }
     }
     if (config.enforceBackwardSlash) {

--- a/src/parser/helper/Helper.ts
+++ b/src/parser/helper/Helper.ts
@@ -25,6 +25,17 @@ export function mapAllFunctional<KeyType, ValueType>(
 }
 
 /**
+ * Looks up the passed string key converted to lower case in the passed map. Returns the retrieved value (if any).
+ * @param map Map from which to retrieve the value.
+ * @param key The key to look up after being converted to lower case. The passed object is not modified.
+ * @return the value retrieved from the map, if any.
+ */
+export function lookupLowerCase<V>(map: Map<string, V>, key: string) {
+    const inLowerCase = key.toLowerCase();
+    return map.get(inLowerCase);
+}
+
+/**
  * Maps all elements of the specified iterable using the specified map. Returns an array of all mapped values,
  * skipping elements for which there is no value available in the map.
  * @param iterator Iterable of elements to map.

--- a/src/parser/helper/Helper.ts
+++ b/src/parser/helper/Helper.ts
@@ -80,7 +80,7 @@ export function formatPrintPath(filePath: string, config: Configuration): string
         // Returns the file path relative to the specified base directory, or the name of the file,
         // if the base path points to this single file.
         result = path.relative(config.sourcesPath, filePath);
-        if (config.sourcesPath.length == 0) {
+        if (config.sourcesPath.length === 0) {
             // The path specified by the user points to a single file,
             // so return the name of the file as path to print.
             config.sourcesPath = path.basename(filePath);

--- a/src/parser/helper/Helper.ts
+++ b/src/parser/helper/Helper.ts
@@ -73,17 +73,22 @@ export function replaceForwardWithBackwardSlashes(path: string) {
  * Formats the specified file path for being output in the way it is configured for this parser run.
  * @param filePath The file path.
  * @param config The configuration for this parser run.
+ * @param pathModule ONLY FOR TESTING PURPOSES: overrides the platform-specific path module.
  */
-export function formatPrintPath(filePath: string, config: Configuration): string {
+export function formatPrintPath(
+    filePath: string,
+    config: Configuration,
+    pathModule = path,
+): string {
     let result = filePath;
     if (config.relativePaths) {
         // Return the file path relative to the specified base directory, or the name of the file,
         // if the base path points to this single file.
-        result = path.relative(config.sourcesPath, filePath);
+        result = pathModule.relative(config.sourcesPath, filePath);
         if (result.length === 0) {
             // The path specified by the user points to a single file,
             // so return the name of the file as path to print.
-            result = path.basename(filePath);
+            result = pathModule.basename(filePath);
         }
     }
     if (config.enforceBackwardSlash) {

--- a/src/parser/helper/Language.test.ts
+++ b/src/parser/helper/Language.test.ts
@@ -1,0 +1,135 @@
+import { assumeLanguageFromFilePath, Language } from "./Language";
+import { getParserTestConfiguration } from "../../../test/metric-end-results/TestHelper";
+import { Configuration } from "../Configuration";
+
+describe("assumeLanguageFromFilePath(...)", () => {
+    it("should extract the language from a supported file extension in UNIX-Style paths", () => {
+        const path = "/path/to/the/File.java";
+        const config = getParserTestConfiguration(path);
+
+        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.Java);
+    });
+
+    it("should extract the language from a supported file extension in DOS-Style paths", () => {
+        const path = "C:\\users\\user\\documents\\File.java";
+        const config = getParserTestConfiguration(path);
+
+        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.Java);
+    });
+
+    it("should treat .h files as C++ per default", () => {
+        const path = "File.h";
+        const config = getParserTestConfiguration(path);
+
+        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.CPlusPlus);
+    });
+
+    it("should treat a .h file as C if configured", () => {
+        const path = "File.h";
+        const config = getParserTestConfiguration(path, true);
+
+        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.C);
+    });
+
+    it("should treat a .h file as C if it lies in a folder specified in the configuration (DOS-style)", () => {
+        const path = "C:\\users\\user\\code\\folder-for-c\\sub-folder\\File.h";
+        const config = new Configuration(
+            "C:\\users\\user\\code",
+            "C:\\users\\user\\code",
+            false,
+            "",
+            false,
+            "folder-for-c",
+            false,
+            false,
+            false,
+        );
+
+        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.C);
+    });
+
+    it("should treat a .h file as C if it lies in a folder specified in the configuration (UNIX-style)", () => {
+        const path = "/path/to/the/code/sub-folder/folder-for-c/sub-folder/File.h";
+        const config = new Configuration(
+            "/path/to/the/code",
+            "invalid/output/path",
+            false,
+            "",
+            false,
+            "folder-for-c",
+            false,
+            false,
+            false,
+        );
+
+        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.C);
+    });
+
+    it("should treat a .h file as C++ if it lies outside of folders specified in the configuration (DOS-style)", () => {
+        const path = "C:\\users\\user\\code\\folder-for-c++\\sub-folder\\File.h";
+        const config = new Configuration(
+            "C:\\users\\user\\code",
+            "C:\\users\\user\\code",
+            false,
+            "",
+            false,
+            "folder-for-c, c-file.h",
+            false,
+            false,
+            false,
+        );
+
+        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.CPlusPlus);
+    });
+
+    it("should treat a .h file as C++ if it lies in outside of folders specified in the configuration (UNIX-style)", () => {
+        const path = "/path/to/the/code/sub-folder/folder-for-c++/sub-folder/File.h";
+        const config = new Configuration(
+            "/path/to/the/code",
+            "invalid/output/path",
+            false,
+            "",
+            false,
+            "folder-for-c, c-file.h",
+            false,
+            false,
+            false,
+        );
+
+        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.CPlusPlus);
+    });
+
+    it("should treat a .h file as C if it has a name specified in the configuration (DOS-style)", () => {
+        const path = "C:\\users\\user\\code\\folder-for-c++\\sub-folder\\c-file.h";
+        const config = new Configuration(
+            "C:\\users\\user\\code",
+            "C:\\users\\user\\code",
+            false,
+            "",
+            false,
+            "folder-for-c, c-file.h",
+            false,
+            false,
+            false,
+        );
+
+        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.C);
+    });
+
+    it("should treat a .h file as C if it has a name specified in the configuration (UNIX-style)", () => {
+        const path = "/path/to/the/code/sub-folder/folder-for-c++/sub-folder/c-file.h";
+        const config = new Configuration(
+            "/path/to/the/code",
+            "invalid/output/path",
+            false,
+            "",
+            false,
+            "folder-for-c, c-file.h",
+            false,
+            false,
+            false,
+        );
+
+        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.C);
+    });
+});

--- a/src/parser/helper/Language.test.ts
+++ b/src/parser/helper/Language.test.ts
@@ -1,135 +1,84 @@
 import { assumeLanguageFromFilePath, Language } from "./Language";
-import { getParserTestConfiguration } from "../../../test/metric-end-results/TestHelper";
-import { Configuration } from "../Configuration";
+import { getTestConfiguration } from "../../../test/metric-end-results/TestHelper";
 import path from "path";
 
 describe("assumeLanguageFromFilePath(...)", () => {
     it("should extract the language from a supported file extension in UNIX-Style paths", () => {
         const filePath = "/path/to/the/File.java";
-        const config = getParserTestConfiguration(filePath);
+        const config = getTestConfiguration(filePath);
 
         expect(assumeLanguageFromFilePath(filePath, config, path.posix)).toBe(Language.Java);
     });
 
     it("should extract the language from a supported file extension in DOS-Style paths", () => {
         const filePath = "C:\\users\\user\\documents\\File.java";
-        const config = getParserTestConfiguration(filePath);
+        const config = getTestConfiguration(filePath);
 
         expect(assumeLanguageFromFilePath(filePath, config, path.win32)).toBe(Language.Java);
     });
 
     it("should treat .h files as C++ per default", () => {
         const filePath = "File.h";
-        const config = getParserTestConfiguration(filePath);
+        const config = getTestConfiguration(filePath);
 
         expect(assumeLanguageFromFilePath(filePath, config)).toBe(Language.CPlusPlus);
     });
 
     it("should treat a .h file as C if configured", () => {
         const filePath = "File.h";
-        const config = getParserTestConfiguration(filePath, true);
+        const config = getTestConfiguration(filePath, { parseAllHAsC: true });
 
         expect(assumeLanguageFromFilePath(filePath, config)).toBe(Language.C);
     });
 
     it("should treat a .h file as C if it lies in a folder specified in the configuration (DOS-style)", () => {
         const filePath = "C:\\users\\user\\code\\folder-for-c\\sub-folder\\File.h";
-        const config = new Configuration(
-            "C:\\users\\user\\code",
-            "invalid/output/path",
-            false,
-            "",
-            false,
-            "folder-for-c",
-            false,
-            false,
-            false,
-        );
+        const config = getTestConfiguration("C:\\users\\user\\code", {
+            parseSomeHAsC: "folder-for-c",
+        });
 
         expect(assumeLanguageFromFilePath(filePath, config, path.win32)).toBe(Language.C);
     });
 
     it("should treat a .h file as C if it lies in a folder specified in the configuration (UNIX-style)", () => {
         const filePath = "/path/to/the/code/sub-folder/folder-for-c/sub-folder/File.h";
-        const config = new Configuration(
-            "/path/to/the/code",
-            "invalid/output/path",
-            false,
-            "",
-            false,
-            "folder-for-c",
-            false,
-            false,
-            false,
-        );
+        const config = getTestConfiguration("/path/to/the/code", { parseSomeHAsC: "folder-for-c" });
 
         expect(assumeLanguageFromFilePath(filePath, config, path.posix)).toBe(Language.C);
     });
 
     it("should treat a .h file as C++ if it lies outside of folders specified in the configuration (DOS-style)", () => {
         const filePath = "C:\\users\\user\\code\\folder-for-c++\\sub-folder\\File.h";
-        const config = new Configuration(
-            "C:\\users\\user\\code",
-            "invalid/output/path",
-            false,
-            "",
-            false,
-            "folder-for-c, c-file.h",
-            false,
-            false,
-            false,
-        );
+        const config = getTestConfiguration("C:\\users\\user\\code", {
+            parseSomeHAsC: "folder-for-c, c-file.h",
+        });
 
         expect(assumeLanguageFromFilePath(filePath, config, path.win32)).toBe(Language.CPlusPlus);
     });
 
     it("should treat a .h file as C++ if it lies in outside of folders specified in the configuration (UNIX-style)", () => {
         const filePath = "/path/to/the/code/sub-folder/folder-for-c++/sub-folder/File.h";
-        const config = new Configuration(
-            "/path/to/the/code",
-            "invalid/output/path",
-            false,
-            "",
-            false,
-            "folder-for-c, c-file.h",
-            false,
-            false,
-            false,
-        );
+        const config = getTestConfiguration("/path/to/the/code", {
+            parseSomeHAsC: "folder-for-c, c-file.h",
+        });
 
         expect(assumeLanguageFromFilePath(filePath, config, path.posix)).toBe(Language.CPlusPlus);
     });
 
     it("should treat a .h file as C if it has a name specified in the configuration (DOS-style)", () => {
         const filePath = "C:\\users\\user\\code\\folder-for-c++\\sub-folder\\c-file.h";
-        const config = new Configuration(
-            "C:\\users\\user\\code",
-            "invalid/output/path",
-            false,
-            "",
-            false,
-            "folder-for-c, c-file.h",
-            false,
-            false,
-            false,
-        );
+        const config = getTestConfiguration("C:\\users\\user\\code", {
+            parseSomeHAsC: "folder-for-c, c-file.h",
+        });
 
         expect(assumeLanguageFromFilePath(filePath, config, path.win32)).toBe(Language.C);
     });
 
     it("should treat a .h file as C if it has a name specified in the configuration (UNIX-style)", () => {
         const filePath = "/path/to/the/code/sub-folder/folder-for-c++/sub-folder/c-file.h";
-        const config = new Configuration(
-            "/path/to/the/code",
-            "invalid/output/path",
-            false,
-            "",
-            false,
-            "folder-for-c, c-file.h",
-            false,
-            false,
-            false,
-        );
+        const config = getTestConfiguration("/path/to/the/code", {
+            parseSomeHAsC: "folder-for-c, c-file.h",
+        });
 
         expect(assumeLanguageFromFilePath(filePath, config, path.posix)).toBe(Language.C);
     });

--- a/src/parser/helper/Language.test.ts
+++ b/src/parser/helper/Language.test.ts
@@ -1,41 +1,42 @@
 import { assumeLanguageFromFilePath, Language } from "./Language";
 import { getParserTestConfiguration } from "../../../test/metric-end-results/TestHelper";
 import { Configuration } from "../Configuration";
+import path from "path";
 
 describe("assumeLanguageFromFilePath(...)", () => {
     it("should extract the language from a supported file extension in UNIX-Style paths", () => {
-        const path = "/path/to/the/File.java";
-        const config = getParserTestConfiguration(path);
+        const filePath = "/path/to/the/File.java";
+        const config = getParserTestConfiguration(filePath);
 
-        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.Java);
+        expect(assumeLanguageFromFilePath(filePath, config, path.posix)).toBe(Language.Java);
     });
 
     it("should extract the language from a supported file extension in DOS-Style paths", () => {
-        const path = "C:\\users\\user\\documents\\File.java";
-        const config = getParserTestConfiguration(path);
+        const filePath = "C:\\users\\user\\documents\\File.java";
+        const config = getParserTestConfiguration(filePath);
 
-        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.Java);
+        expect(assumeLanguageFromFilePath(filePath, config, path.win32)).toBe(Language.Java);
     });
 
     it("should treat .h files as C++ per default", () => {
-        const path = "File.h";
-        const config = getParserTestConfiguration(path);
+        const filePath = "File.h";
+        const config = getParserTestConfiguration(filePath);
 
-        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.CPlusPlus);
+        expect(assumeLanguageFromFilePath(filePath, config)).toBe(Language.CPlusPlus);
     });
 
     it("should treat a .h file as C if configured", () => {
-        const path = "File.h";
-        const config = getParserTestConfiguration(path, true);
+        const filePath = "File.h";
+        const config = getParserTestConfiguration(filePath, true);
 
-        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.C);
+        expect(assumeLanguageFromFilePath(filePath, config)).toBe(Language.C);
     });
 
     it("should treat a .h file as C if it lies in a folder specified in the configuration (DOS-style)", () => {
-        const path = "C:\\users\\user\\code\\folder-for-c\\sub-folder\\File.h";
+        const filePath = "C:\\users\\user\\code\\folder-for-c\\sub-folder\\File.h";
         const config = new Configuration(
             "C:\\users\\user\\code",
-            "C:\\users\\user\\code",
+            "invalid/output/path",
             false,
             "",
             false,
@@ -45,11 +46,11 @@ describe("assumeLanguageFromFilePath(...)", () => {
             false,
         );
 
-        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.C);
+        expect(assumeLanguageFromFilePath(filePath, config, path.win32)).toBe(Language.C);
     });
 
     it("should treat a .h file as C if it lies in a folder specified in the configuration (UNIX-style)", () => {
-        const path = "/path/to/the/code/sub-folder/folder-for-c/sub-folder/File.h";
+        const filePath = "/path/to/the/code/sub-folder/folder-for-c/sub-folder/File.h";
         const config = new Configuration(
             "/path/to/the/code",
             "invalid/output/path",
@@ -62,14 +63,14 @@ describe("assumeLanguageFromFilePath(...)", () => {
             false,
         );
 
-        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.C);
+        expect(assumeLanguageFromFilePath(filePath, config, path.posix)).toBe(Language.C);
     });
 
     it("should treat a .h file as C++ if it lies outside of folders specified in the configuration (DOS-style)", () => {
-        const path = "C:\\users\\user\\code\\folder-for-c++\\sub-folder\\File.h";
+        const filePath = "C:\\users\\user\\code\\folder-for-c++\\sub-folder\\File.h";
         const config = new Configuration(
             "C:\\users\\user\\code",
-            "C:\\users\\user\\code",
+            "invalid/output/path",
             false,
             "",
             false,
@@ -79,11 +80,11 @@ describe("assumeLanguageFromFilePath(...)", () => {
             false,
         );
 
-        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.CPlusPlus);
+        expect(assumeLanguageFromFilePath(filePath, config, path.win32)).toBe(Language.CPlusPlus);
     });
 
     it("should treat a .h file as C++ if it lies in outside of folders specified in the configuration (UNIX-style)", () => {
-        const path = "/path/to/the/code/sub-folder/folder-for-c++/sub-folder/File.h";
+        const filePath = "/path/to/the/code/sub-folder/folder-for-c++/sub-folder/File.h";
         const config = new Configuration(
             "/path/to/the/code",
             "invalid/output/path",
@@ -96,14 +97,14 @@ describe("assumeLanguageFromFilePath(...)", () => {
             false,
         );
 
-        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.CPlusPlus);
+        expect(assumeLanguageFromFilePath(filePath, config, path.posix)).toBe(Language.CPlusPlus);
     });
 
     it("should treat a .h file as C if it has a name specified in the configuration (DOS-style)", () => {
-        const path = "C:\\users\\user\\code\\folder-for-c++\\sub-folder\\c-file.h";
+        const filePath = "C:\\users\\user\\code\\folder-for-c++\\sub-folder\\c-file.h";
         const config = new Configuration(
             "C:\\users\\user\\code",
-            "C:\\users\\user\\code",
+            "invalid/output/path",
             false,
             "",
             false,
@@ -113,11 +114,11 @@ describe("assumeLanguageFromFilePath(...)", () => {
             false,
         );
 
-        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.C);
+        expect(assumeLanguageFromFilePath(filePath, config, path.win32)).toBe(Language.C);
     });
 
     it("should treat a .h file as C if it has a name specified in the configuration (UNIX-style)", () => {
-        const path = "/path/to/the/code/sub-folder/folder-for-c++/sub-folder/c-file.h";
+        const filePath = "/path/to/the/code/sub-folder/folder-for-c++/sub-folder/c-file.h";
         const config = new Configuration(
             "/path/to/the/code",
             "invalid/output/path",
@@ -130,6 +131,6 @@ describe("assumeLanguageFromFilePath(...)", () => {
             false,
         );
 
-        expect(assumeLanguageFromFilePath(path, config)).toBe(Language.C);
+        expect(assumeLanguageFromFilePath(filePath, config, path.posix)).toBe(Language.C);
     });
 });

--- a/src/parser/helper/Language.ts
+++ b/src/parser/helper/Language.ts
@@ -13,7 +13,7 @@ import Bash from "tree-sitter-bash";
 import C from "tree-sitter-c";
 import { ConstantTwoWayMap } from "./ConstantTwoWayMap";
 import { Configuration } from "../Configuration";
-import { getFileExtension, replaceForwardWithBackwardSlashes } from "./Helper";
+import { getFileExtension, lookupLowerCase, replaceForwardWithBackwardSlashes } from "./Helper";
 import path from "path";
 
 /**
@@ -135,17 +135,15 @@ export function assumeLanguageFromFilePath(
     if (fileExtension === "h") {
         if (shouldHBeParsedAsC(filePath, config, pathModule)) {
             return Language.C;
-        } else {
-            return Language.CPlusPlus;
         }
+        return Language.CPlusPlus;
     }
 
-    let result = caseSensitiveFileExtensionToLanguage.get(fileExtension);
-    const inLowerCase = fileExtension.toLowerCase();
-    if (result === undefined) {
-        result = fileExtensionToLanguage.get(inLowerCase);
+    const resultCaseSensitive = caseSensitiveFileExtensionToLanguage.get(fileExtension);
+    if (resultCaseSensitive !== undefined) {
+        return resultCaseSensitive;
     }
-    return result;
+    return lookupLowerCase(fileExtensionToLanguage, fileExtension);
 }
 
 /**

--- a/src/parser/helper/Language.ts
+++ b/src/parser/helper/Language.ts
@@ -134,17 +134,17 @@ export function assumeLanguageFromFilePath(
 
     // Handling of the parse .h as C option:
     if (fileExtension === "h") {
-        if (config.parseAllAsC) {
+        if (config.parseAllHAsC) {
             return Language.C;
         }
-        if (config.parseSomeAsC.size > 0) {
+        if (config.parseSomeHAsC.size > 0) {
             // Use the path relative to the sources path to avoid the unintuitive behaviour
             // that higher-level folders are evaluated for this:
             const relativePath = pathModule.relative(config.sourcesPath, filePath);
             const backwardSlashRelpath = replaceForwardWithBackwardSlashes(relativePath);
             const relpathSplitted = backwardSlashRelpath.split("\\");
             for (const pathElement of relpathSplitted) {
-                if (config.parseSomeAsC.has(pathElement)) {
+                if (config.parseSomeHAsC.has(pathElement)) {
                     return Language.C;
                 }
             }

--- a/src/parser/helper/Language.ts
+++ b/src/parser/helper/Language.ts
@@ -123,8 +123,13 @@ const caseSensitiveFileExtensionToLanguage = new Map([
  * Estimates the language of a file based upon the file extension and file path.
  * @param filePath Path to the file, including the file extension.
  * @param config Configuration to apply.
+ * @param pathModule ONLY FOR TESTING PURPOSES: overrides the platform-specific path module.
  */
-export function assumeLanguageFromFilePath(filePath: string, config: Configuration) {
+export function assumeLanguageFromFilePath(
+    filePath: string,
+    config: Configuration,
+    pathModule = path,
+) {
     const fileExtension: string = getFileExtension(filePath);
 
     // Handling of the parse .h as C option:
@@ -135,7 +140,7 @@ export function assumeLanguageFromFilePath(filePath: string, config: Configurati
         if (config.parseSomeAsC.size > 0) {
             // Use the path relative to the sources path to avoid the unintuitive behaviour
             // that higher-level folders are evaluated for this:
-            const relativePath = path.relative(config.sourcesPath, filePath);
+            const relativePath = pathModule.relative(config.sourcesPath, filePath);
             const backwardSlashRelpath = replaceForwardWithBackwardSlashes(relativePath);
             const relpathSplitted = backwardSlashRelpath.split("\\");
             for (const pathElement of relpathSplitted) {

--- a/src/parser/helper/Language.ts
+++ b/src/parser/helper/Language.ts
@@ -10,7 +10,10 @@ import TypeScript from "tree-sitter-typescript";
 import Ruby from "tree-sitter-ruby";
 import Rust from "tree-sitter-rust";
 import Bash from "tree-sitter-bash";
+import C from "tree-sitter-c";
 import { ConstantTwoWayMap } from "./ConstantTwoWayMap";
+import { Configuration } from "../Configuration";
+import { getFileExtension, replaceForwardWithBackwardSlashes } from "./Helper";
 
 /**
  * Enum of all supported programming languages.
@@ -29,6 +32,7 @@ export const enum Language {
     Ruby,
     Rust,
     Bash,
+    C,
 }
 
 /**
@@ -54,6 +58,7 @@ export const languageToAbbreviation = new ConstantTwoWayMap<Language, string>(
         [Language.Ruby, "rb"],
         [Language.Rust, "rs"],
         [Language.Bash, "sh"],
+        [Language.C, "c"],
     ]),
 );
 
@@ -74,18 +79,19 @@ export const languageToGrammar = new Map([
     [Language.Ruby, Ruby],
     [Language.Rust, Rust],
     [Language.Bash, Bash],
+    [Language.C, C],
 ]);
 
 /**
  * Maps supported file extensions to the corresponding programming languages.
+ * In lower case. This list is for file extensions which are not case-sensitive.
  */
-export const fileExtensionToLanguage = new Map([
+const fileExtensionToLanguage = new Map([
     ["cs", Language.CSharp],
     ["cpp", Language.CPlusPlus],
     ["cp", Language.CPlusPlus],
     ["cxx", Language.CPlusPlus],
     ["cc", Language.CPlusPlus],
-    ["h", Language.CPlusPlus],
     ["hpp", Language.CPlusPlus],
     ["hxx", Language.CPlusPlus],
     ["hh", Language.CPlusPlus],
@@ -101,6 +107,44 @@ export const fileExtensionToLanguage = new Map([
     ["rs", Language.Rust],
     ["sh", Language.Bash],
 ]);
+
+/**
+ * Maps supported file extensions to the corresponding programming languages.
+ * For case-sensitive file extensions.
+ */
+const caseSensitiveFileExtensionToLanguage = new Map([
+    ["c", Language.C],
+    ["C", Language.CPlusPlus],
+    ["h", Language.CPlusPlus],
+    ["H", Language.CPlusPlus],
+]);
+
+/**
+ * Estimates the language of a file based upon the file extension and file path.
+ * @param filePath Path to the file, including the file extension.
+ * @param config Configuration to apply.
+ */
+export function assumeLanguageFromFilePath(filePath: string, config: Configuration) {
+    const fileExtension: string = getFileExtension(filePath);
+
+    // Handling of the parse .h as C option:
+    if (fileExtension === "h" && config.parseAsC.size > 0) {
+        const backwardSlashPath = replaceForwardWithBackwardSlashes(filePath);
+        const pathSplitted = backwardSlashPath.split("\\");
+        for (const pathElement of pathSplitted) {
+            if (config.parseAsC.has(pathElement)) {
+                return Language.C;
+            }
+        }
+    }
+
+    let result = caseSensitiveFileExtensionToLanguage.get(fileExtension);
+    const inLowerCase = fileExtension.toLowerCase();
+    if (result === undefined) {
+        result = fileExtensionToLanguage.get(inLowerCase);
+    }
+    return result;
+}
 
 /**
  * Maps supported file extensions to the corresponding language grammar.

--- a/src/parser/helper/TreeParser.ts
+++ b/src/parser/helper/TreeParser.ts
@@ -1,9 +1,8 @@
 import fs from "fs";
-import { fileExtensionToLanguage, Language, languageToGrammar } from "./Language";
+import { assumeLanguageFromFilePath, Language, languageToGrammar } from "./Language";
 import Parser from "tree-sitter";
 import { ParsedFile, SourceFile, UnsupportedFile } from "../metrics/Metric";
 import { Configuration } from "../Configuration";
-import { getFileExtension } from "./Helper";
 
 export class TreeParser {
     private static cache: Map<string, SourceFile> = new Map();
@@ -42,12 +41,11 @@ export class TreeParser {
         filePath: string,
         config: Configuration,
     ): ParsedFile | UnsupportedFile {
-        const fileExtension = getFileExtension(filePath);
-        let language = fileExtensionToLanguage.get(fileExtension);
+        let language = assumeLanguageFromFilePath(filePath, config);
 
         if (language === undefined) {
             // Unsupported file language, return
-            const unsupportedFile = new UnsupportedFile(filePath, fileExtension);
+            const unsupportedFile = new UnsupportedFile(filePath);
             TreeParser.cache.set(filePath, unsupportedFile);
             return unsupportedFile;
         }
@@ -74,7 +72,7 @@ export class TreeParser {
             throw new Error("Root node of syntax tree for file " + filePath + " is undefined!");
         }
 
-        const parsedFile = new ParsedFile(filePath, fileExtension, language, tree);
+        const parsedFile = new ParsedFile(filePath, language, tree);
         TreeParser.cache.set(filePath, parsedFile);
 
         return parsedFile;

--- a/src/parser/metrics/Classes.ts
+++ b/src/parser/metrics/Classes.ts
@@ -19,10 +19,10 @@ export class Classes implements Metric {
     constructor(allNodeTypes: ExpressionMetricMapping[]) {
         this.statementsSuperSet = getQueryStatements(allNodeTypes, this.getName());
 
-        this.addQueriesForC_Cpp();
+        this.addQueriesForCAndCpp();
     }
 
-    addQueriesForC_Cpp() {
+    addQueriesForCAndCpp() {
         this.statementsSuperSet.push(
             new SimpleLanguageSpecificQueryStatement(
                 "(struct_specifier body: (field_declaration_list)) @struct_definition",

--- a/src/parser/metrics/Metric.ts
+++ b/src/parser/metrics/Metric.ts
@@ -94,7 +94,7 @@ export class UnsupportedFile extends SourceFile {
 }
 
 /**
- * Represents a supported file to be analyzed for metrics, including its path, language and parsed syntax tree.
+ * Represents a parsed file written in a supported language that can be analyzed for metrics.
  */
 export class ParsedFile extends SourceFile {
     /**

--- a/src/parser/metrics/Metric.ts
+++ b/src/parser/metrics/Metric.ts
@@ -79,14 +79,8 @@ export abstract class SourceFile {
      */
     filePath: string;
 
-    /**
-     * File extension of the file.
-     */
-    fileExtension: string;
-
-    protected constructor(filePath: string, fileExtension: string) {
+    protected constructor(filePath: string) {
         this.filePath = filePath;
-        this.fileExtension = fileExtension;
     }
 }
 
@@ -94,13 +88,13 @@ export abstract class SourceFile {
  * Represents a file written in an unsupported language.
  */
 export class UnsupportedFile extends SourceFile {
-    constructor(filePath: string, fileExtension: string) {
-        super(filePath, fileExtension);
+    constructor(filePath: string) {
+        super(filePath);
     }
 }
 
 /**
- * Represents a supported file to be analyzed for metrics, including its path, file extension, language and parsed syntax tree.
+ * Represents a supported file to be analyzed for metrics, including its path, language and parsed syntax tree.
  */
 export class ParsedFile extends SourceFile {
     /**
@@ -113,8 +107,8 @@ export class ParsedFile extends SourceFile {
      */
     tree: Tree;
 
-    constructor(filePath: string, fileExtension: string, language: Language, tree: Tree) {
-        super(filePath, fileExtension);
+    constructor(filePath: string, language: Language, tree: Tree) {
+        super(filePath);
         this.language = language;
         this.tree = tree;
     }

--- a/test/metric-end-results/C-Metrics.test.ts
+++ b/test/metric-end-results/C-Metrics.test.ts
@@ -1,0 +1,87 @@
+import { expectFileMetric, parseAllFileMetrics } from "./TestHelper";
+import { FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
+
+describe("C metrics tests", () => {
+    const cTestResourcesPath = "./resources/c/";
+
+    let results: Map<string, Map<string, MetricResult>>;
+
+    const testFileMetric = (inputPath, metric, expected) =>
+        expectFileMetric(results, inputPath, metric, expected);
+
+    beforeAll(async () => {
+        results = await parseAllFileMetrics(cTestResourcesPath, true);
+    });
+
+    describe("Parsing the C complexity metric", () => {
+        it("should be correct for a source code file", () => {
+            testFileMetric(cTestResourcesPath + "c-example-code.c", FileMetric.complexity, 14);
+        });
+
+        it("should be correct for a header file", () => {
+            testFileMetric(cTestResourcesPath + "c-example-header.h", FileMetric.complexity, 1);
+        });
+    });
+
+    describe("Parsing the C classes metric", () => {
+        it("should return zero for a source code file without any structs, enums or unions", () => {
+            testFileMetric(cTestResourcesPath + "c-example-code.c", FileMetric.classes, 0);
+        });
+
+        it("should be correct for a header file with structs, enums or unions", () => {
+            testFileMetric(cTestResourcesPath + "c-example-header.h", FileMetric.classes, 9);
+        });
+    });
+
+    describe("Parsing the C functions metric", () => {
+        it("should count function definitions", () => {
+            testFileMetric(cTestResourcesPath + "c-example-code.c", FileMetric.functions, 2);
+        });
+
+        it("should count function declarations", () => {
+            testFileMetric(cTestResourcesPath + "c-example-header.h", FileMetric.functions, 1);
+        });
+    });
+
+    describe("Parsing the C comment lines metric", () => {
+        it("should return zero for a source code file without any comments", () => {
+            testFileMetric(cTestResourcesPath + "c-example-code.c", FileMetric.commentLines, 0);
+        });
+
+        it("should count block comments and C++ style inline comments correctly", () => {
+            testFileMetric(cTestResourcesPath + "c-example-header.h", FileMetric.commentLines, 17);
+        });
+    });
+
+    describe("Parsing the C lines of code metric", () => {
+        it("should count the lines of code correctly for a non-empty source code file", () => {
+            testFileMetric(cTestResourcesPath + "c-example-code.c", FileMetric.linesOfCode, 58);
+        });
+
+        it("should count the lines of code correctly for a non-empty header file", () => {
+            testFileMetric(cTestResourcesPath + "c-example-header.h", FileMetric.linesOfCode, 71);
+        });
+
+        it("should count one line for an empty file", () => {
+            testFileMetric(cTestResourcesPath + "empty.c", FileMetric.linesOfCode, 1);
+        });
+    });
+
+    describe("Parsing the C real lines of code metric", () => {
+        it("should count correctly for a source code file", () => {
+            testFileMetric(cTestResourcesPath + "c-example-code.c", FileMetric.realLinesOfCode, 49);
+        });
+
+        it("should count correctly for a non-empty header file, ignoring comments and empty lines", () => {
+            testFileMetric(
+                cTestResourcesPath + "c-example-header.h",
+                FileMetric.realLinesOfCode,
+                38,
+            );
+        });
+
+        it("should count correctly for an empty file", () => {
+            testFileMetric(cTestResourcesPath + "empty.c", FileMetric.realLinesOfCode, 0);
+        });
+    });
+});

--- a/test/metric-end-results/CPlusPlusMetrics.test.ts
+++ b/test/metric-end-results/CPlusPlusMetrics.test.ts
@@ -81,7 +81,7 @@ describe("C++ metrics tests", () => {
         });
 
         it("should also count for structs", () => {
-            testFileMetric(cppTestResourcesPath + "structs.hpp", FileMetric.classes, 4);
+            testFileMetric(cppTestResourcesPath + "structs.hpp", FileMetric.classes, 6);
         });
 
         it("should also count class declarations in source code files", () => {

--- a/test/metric-end-results/CPlusPlusMetrics.test.ts
+++ b/test/metric-end-results/CPlusPlusMetrics.test.ts
@@ -91,6 +91,10 @@ describe("C++ metrics tests", () => {
         it("should count enums and unions as class", () => {
             testFileMetric(cppTestResourcesPath + "enums_and_unions.cpp", FileMetric.classes, 20);
         });
+
+        it("should not count typedefs without definition of a new class/struct/union", () => {
+            testFileMetric(cppTestResourcesPath + "typedefs.h", FileMetric.classes, 11);
+        });
     });
 
     describe("parses C++ functions metric", () => {

--- a/test/metric-end-results/CPlusPlusMetrics.test.ts
+++ b/test/metric-end-results/CPlusPlusMetrics.test.ts
@@ -87,6 +87,10 @@ describe("C++ metrics tests", () => {
         it("should also count class declarations in source code files", () => {
             testFileMetric(cppTestResourcesPath + "source_class.cxx", FileMetric.classes, 1);
         });
+
+        it("should count enums and unions as class", () => {
+            testFileMetric(cppTestResourcesPath + "enums_and_unions.cpp", FileMetric.classes, 20);
+        });
     });
 
     describe("parses C++ functions metric", () => {

--- a/test/metric-end-results/TestHelper.ts
+++ b/test/metric-end-results/TestHelper.ts
@@ -7,6 +7,7 @@ import { strcmp } from "../../src/parser/helper/Helper";
 /**
  * Gets a parser configuration for the test cases.
  * @param sourcesPath Path to the source files.
+ * @param parseAllAsC Whether to parse all .h files as C instead of C++.
  * @param parseDependencies Whether to enable parsing dependencies.
  * @param formatFilePaths Whether to format the output file paths to be independent
  * of project location and platform.
@@ -16,8 +17,9 @@ import { strcmp } from "../../src/parser/helper/Helper";
  * results.fileMetrics.get(formatPrintPath(inputPath, config))
  * </code></pre>
  */
-export function getParserConfiguration(
+export function getParserTestConfiguration(
     sourcesPath: string,
+    parseAllAsC = false,
     parseDependencies = false,
     formatFilePaths = false,
 ) {
@@ -25,6 +27,8 @@ export function getParserConfiguration(
         sourcesPath,
         "invalid/output/path",
         parseDependencies,
+        "",
+        parseAllAsC,
         "",
         false,
         formatFilePaths, // For project location-independent testing
@@ -63,7 +67,7 @@ export async function parseAndTestFileMetric(
     expected: number,
 ) {
     const realInputPath = fs.realpathSync(inputPath);
-    const parser = new GenericParser(getParserConfiguration(realInputPath));
+    const parser = new GenericParser(getParserTestConfiguration(realInputPath));
     const results = await parser.calculateMetrics();
     expect(results.fileMetrics.get(realInputPath)?.get(metric)?.metricValue).toBe(expected);
 }
@@ -75,7 +79,7 @@ export async function parseAndTestFileMetric(
  */
 export async function parseAllFileMetrics(inputPath: string) {
     const realInputPath = fs.realpathSync(inputPath);
-    const parser = new GenericParser(getParserConfiguration(realInputPath));
+    const parser = new GenericParser(getParserTestConfiguration(realInputPath));
     return (await parser.calculateMetrics()).fileMetrics;
 }
 
@@ -104,7 +108,7 @@ export function expectFileMetric(
  */
 export async function getFileMetrics(inputPath: string) {
     const realInputPath = fs.realpathSync(inputPath);
-    const parser = new GenericParser(getParserConfiguration(realInputPath));
+    const parser = new GenericParser(getParserTestConfiguration(realInputPath));
     return await parser.calculateMetrics();
 }
 
@@ -114,7 +118,7 @@ export async function getFileMetrics(inputPath: string) {
  */
 export async function getCouplingMetrics(inputPath: string) {
     const realInputPath = fs.realpathSync(inputPath);
-    const parser = new GenericParser(getParserConfiguration(realInputPath, true, true));
+    const parser = new GenericParser(getParserTestConfiguration(realInputPath, false, true, true));
 
     const results = await parser.calculateMetrics();
     const couplingResult = results.couplingMetrics;

--- a/test/metric-end-results/TestHelper.ts
+++ b/test/metric-end-results/TestHelper.ts
@@ -1,39 +1,46 @@
 import fs from "fs";
 import { GenericParser } from "../../src/parser/GenericParser";
-import { Configuration } from "../../src/parser/Configuration";
+import { ConfigurationParams, Configuration } from "../../src/parser/Configuration";
 import { CouplingResult, FileMetric, MetricResult } from "../../src/parser/metrics/Metric";
 import { strcmp } from "../../src/parser/helper/Helper";
 
 /**
- * Gets a parser configuration for the test cases.
+ * Gets a configuration for test cases.
  * @param sourcesPath Path to the source files.
- * @param parseAllAsC Whether to parse all .h files as C instead of C++.
- * @param parseDependencies Whether to enable parsing dependencies.
- * @param formatFilePaths Whether to format the output file paths to be independent
- * of project location and platform.
- * When this is enabled, do not forget to also format the file path when accessing metric results from the output.
+ * @param customOverrides Partial {@link ConfigurationParams} object for overriding parts of the default test configuration.
+ * @param formatFilePaths Whether to format the output file paths to be independent of project location and platform.
+ * If set to true, it sets the necessary configuration options and may override custom overrides.
+ * When using this option, do not forget to also format the file path when accessing metric results from the output.
  * You should use {@link formatPrintPath} for this, e.g.:
  * <pre><code>
  * results.fileMetrics.get(formatPrintPath(inputPath, config))
  * </code></pre>
+ *
+ * @return A configuration for testing purposes.
  */
-export function getParserTestConfiguration(
+export function getTestConfiguration(
     sourcesPath: string,
-    parseAllAsC = false,
-    parseDependencies = false,
+    customOverrides: Partial<ConfigurationParams> = {},
     formatFilePaths = false,
 ) {
-    return new Configuration(
-        sourcesPath,
-        "invalid/output/path",
-        parseDependencies,
-        "",
-        parseAllAsC,
-        "",
-        false,
-        formatFilePaths, // For project location-independent testing
-        formatFilePaths, // For platform-independent testing
-    );
+    let configParams: ConfigurationParams = {
+        sourcesPath: sourcesPath,
+        outputPath: "invalid/output/path",
+        parseDependencies: false,
+        exclusions: "",
+        parseAllHAsC: false,
+        parseSomeHAsC: "",
+        compress: false,
+        relativePaths: false,
+    };
+    configParams = { ...configParams, ...customOverrides };
+
+    if (formatFilePaths) {
+        configParams.relativePaths = true;
+        configParams.enforceBackwardSlash = true;
+    }
+
+    return new Configuration(configParams);
 }
 /**
  * Sorts the contents of the specified {@link CouplingResult} in a deterministic way.
@@ -67,7 +74,7 @@ export async function parseAndTestFileMetric(
     expected: number,
 ) {
     const realInputPath = fs.realpathSync(inputPath);
-    const parser = new GenericParser(getParserTestConfiguration(realInputPath));
+    const parser = new GenericParser(getTestConfiguration(realInputPath));
     const results = await parser.calculateMetrics();
     expect(results.fileMetrics.get(realInputPath)?.get(metric)?.metricValue).toBe(expected);
 }
@@ -75,12 +82,14 @@ export async function parseAndTestFileMetric(
 /**
  * Calculates all file metrics for all supported files that can be found under the specified input path.
  * @param inputPath Path to the source code files to parse.
- * @param parseAllAsC Whether to parse all .h files as C instead of C++ files.
+ * @param parseHAsC Whether to parse all .h files as C instead of C++ files.
  * @return Map that maps the absolute file paths to the corresponding map of calculated file metric results.
  */
-export async function parseAllFileMetrics(inputPath: string, parseAllAsC = false) {
+export async function parseAllFileMetrics(inputPath: string, parseHAsC = false) {
     const realInputPath = fs.realpathSync(inputPath);
-    const parser = new GenericParser(getParserTestConfiguration(realInputPath, parseAllAsC));
+    const parser = new GenericParser(
+        getTestConfiguration(realInputPath, { parseAllHAsC: parseHAsC }),
+    );
     return (await parser.calculateMetrics()).fileMetrics;
 }
 
@@ -109,7 +118,7 @@ export function expectFileMetric(
  */
 export async function getFileMetrics(inputPath: string) {
     const realInputPath = fs.realpathSync(inputPath);
-    const parser = new GenericParser(getParserTestConfiguration(realInputPath));
+    const parser = new GenericParser(getTestConfiguration(realInputPath));
     return await parser.calculateMetrics();
 }
 
@@ -119,7 +128,9 @@ export async function getFileMetrics(inputPath: string) {
  */
 export async function getCouplingMetrics(inputPath: string) {
     const realInputPath = fs.realpathSync(inputPath);
-    const parser = new GenericParser(getParserTestConfiguration(realInputPath, false, true, true));
+    const parser = new GenericParser(
+        getTestConfiguration(realInputPath, { parseDependencies: true }, true),
+    );
 
     const results = await parser.calculateMetrics();
     const couplingResult = results.couplingMetrics;

--- a/test/metric-end-results/TestHelper.ts
+++ b/test/metric-end-results/TestHelper.ts
@@ -75,11 +75,12 @@ export async function parseAndTestFileMetric(
 /**
  * Calculates all file metrics for all supported files that can be found under the specified input path.
  * @param inputPath Path to the source code files to parse.
+ * @param parseAllAsC Whether to parse all .h files as C instead of C++ files.
  * @return Map that maps the absolute file paths to the corresponding map of calculated file metric results.
  */
-export async function parseAllFileMetrics(inputPath: string) {
+export async function parseAllFileMetrics(inputPath: string, parseAllAsC = false) {
     const realInputPath = fs.realpathSync(inputPath);
-    const parser = new GenericParser(getParserTestConfiguration(realInputPath));
+    const parser = new GenericParser(getParserTestConfiguration(realInputPath, parseAllAsC));
     return (await parser.calculateMetrics()).fileMetrics;
 }
 

--- a/test/metric-end-results/UnsupportedFiles.test.ts
+++ b/test/metric-end-results/UnsupportedFiles.test.ts
@@ -1,4 +1,4 @@
-import { expectFileMetric, getParserTestConfiguration } from "./TestHelper";
+import { expectFileMetric, getTestConfiguration } from "./TestHelper";
 import fs from "fs";
 import { GenericParser } from "../../src/parser/GenericParser";
 import { FileMetric } from "../../src/parser/metrics/Metric";
@@ -13,7 +13,7 @@ describe("Test for handling unsupported files, with unknown or no file extension
 
     beforeAll(async () => {
         const realInputPath = fs.realpathSync(unsupportedTestResourcesPath);
-        const parser = new GenericParser(getParserTestConfiguration(realInputPath));
+        const parser = new GenericParser(getTestConfiguration(realInputPath));
         results = await parser.calculateMetrics();
     });
 

--- a/test/metric-end-results/UnsupportedFiles.test.ts
+++ b/test/metric-end-results/UnsupportedFiles.test.ts
@@ -1,4 +1,4 @@
-import { expectFileMetric, getParserConfiguration } from "./TestHelper";
+import { expectFileMetric, getParserTestConfiguration } from "./TestHelper";
 import fs from "fs";
 import { GenericParser } from "../../src/parser/GenericParser";
 import { FileMetric } from "../../src/parser/metrics/Metric";
@@ -13,7 +13,7 @@ describe("Test for handling unsupported files, with unknown or no file extension
 
     beforeAll(async () => {
         const realInputPath = fs.realpathSync(unsupportedTestResourcesPath);
-        const parser = new GenericParser(getParserConfiguration(realInputPath));
+        const parser = new GenericParser(getParserTestConfiguration(realInputPath));
         results = await parser.calculateMetrics();
     });
 


### PR DESCRIPTION
Adds support for the C programming language

Includes the following further changes:

- New command line options `parse-h-as-c` and `parse-some-h-as-c` to decide that (some) .h header files should be parsed as C files instead of C++ files. C++ remains the default for .h files, as it is mostly a superset of C.
- Refactored the Configuration constructor to make parameters more explicit
- Added documentation for all available command line options to the Readme, removed outdated information.
- Added system-independent unit tests for the new `assumeLanguageFromFilePath(...)` function that realizes the new command line options.
- Added support and test cases for C and C++ enums and unions.
- Added special queries for the C and C++ classes metric to avoid the duplicated counting of classes, structs, enums or unions when using `typedef` statements like `typedef class name alias` or forward declarations like `class A; class A {};`. Also considers opaque enums.
- Added test cases for the typedef and forward declaration issues mentioned above.
- Fixes a bug in the `formatPrintPath(...)` function of Helper.ts that resulted in an empty file path when the user supplied sources path is a path to a single file.
- Added system-independent unit tests for `formatPrintPath(...)` to avoid regression, tested for both UNIX (/.../.../...) and DOS-style (C:\\...\\...\\...) paths.


Closes #189