### PR TITLE
Add template and contributing guide for PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+# {Meaningful title}
+
+_**Please read the [CONTRIBUTING.md](https://github.com/MaibornWolff/metric-gardener/blob/main/CONTRIBUTING.md) before opening a PR.**_
+
+{Issue/Closes}: #
+
+## Description
+
+**Descriptive pull request text**, answering:
+- What problem/issue are you fixing?
+- What does this PR implement and how?
+
+## Definition of Done
+
+A PR is only ready for merge once all the following acceptance criteria are fulfilled:
+* [ ]  All TODOs related to this PR have been closed
+* [ ]  There are automated tests for newly written code and bug fixes
+* [ ]  All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
+* [ ]  Documentation ([README.md](https://github.com/MaibornWolff/metric-gardener/blob/main/README.md), [UPDATE_GRAMMARS.md](https://github.com/MaibornWolff/metric-gardener/blob/main/UPDATE_GRAMMARS.md)) has been updated
+
+## Screenshots or gifs
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,3 +75,11 @@ This results in the following structure for commit messages:
     ```
 
 -   `tech: improve handling of errors in GenericParser.ts #4`
+
+### Pull Requests
+
+Follow the given template when opening the PR
+
+-   Give the PR a meaningful title to describe what it changes. E.g. issue or branch name.
+-   Add the correct labels
+-   The PR Assignee is only used by the reviewer to see who is reviewing it


### PR DESCRIPTION
# Add template and contributing guide for PR
Closes: #200

## Description
- Add PR template like in CodeCharta, but with difference in DoD (manual tests and CHANGELOG.md)
- Add rules for contributing like CodeCharta.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
* [x]  All TODOs related to this PR have been closed
* [x]  There are automated tests for newly written code and bug fixes
* [x]  All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
* [x]  Documentation ([README.md](https://github.com/MaibornWolff/metric-gardener/blob/main/README.md), [UPDATE_GRAMMARS.md](https://github.com/MaibornWolff/metric-gardener/blob/main/UPDATE_GRAMMARS.md)) has been updated