### PR TITLE
Fix husky pre-push regex checking

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,13 +4,12 @@
 validate_branch_name() {
   local branch=$(git rev-parse --abbrev-ref HEAD)
 
-  if [[ $branch =~ ^renovate ]]
-  then
-      exit 0
+  if echo $branch | grep -Eq ^renovate; then
+    exit 0
   fi
 
   local regex="^(main|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\/[0-9]+\/[a-z0-9-]+)$"
-  if ! [[ $branch =~ $regex ]]; then
+  if ! echo $branch | grep -Eq $regex; then
     echo "Your push was rejected due to a violation of our naming conventions for branches"
     echo "Examples: feat/1234/add-my-feature, see CONTRIBUTING.md for details"
     exit 1


### PR DESCRIPTION
# Fix husky pre-push regex checking

Closes: #208

## Description

Fixes this issue: https://stackoverflow.com/questions/12230690/string-comparison-in-bash-not-found
Using this template: https://stackoverflow.com/questions/30647654/how-to-write-and-match-regular-expressions-in-bin-sh-script

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
* [x]  All TODOs related to this PR have been closed
* [x]  There are automated tests for newly written code and bug fixes
* [x]  All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
* [x]  Documentation ([README.md](https://github.com/MaibornWolff/metric-gardener/blob/main/README.md), [UPDATE_GRAMMARS.md](https://github.com/MaibornWolff/metric-gardener/blob/main/UPDATE_GRAMMARS.md)) has been updated

