### PR TITLE
Set jest maxWorkers to 64 to further mitigate race condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "scripts": {
         "start": "tsc && node dist/src/app.js",
-        "test": "tsc && jest --maxWorkers=24",
+        "test": "tsc && jest --maxWorkers=64",
         "format": "prettier --write \"./**/*\"",
         "format:quick": "pretty-quick --staged",
         "format:check": "prettier --check \"./**/*\"",


### PR DESCRIPTION
# Set jest maxWorkers to 64 to further mitigate race condition

Raised the `--maxWorkers` option for jest from 24 to 64 to reflect our increased number of test files.

This does not resolve the root cause of #65

## Description

Increasing the `--maxWorkers` option for jest reduces the probablitly of the race condition significantly. Should be enough to make the CI pipeline to run sucessfully in most cases.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
* [x]  All TODOs related to this PR have been closed
* [x]  There are automated tests for newly written code and bug fixes
* [x]  All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
* [x]  Documentation ([README.md](https://github.com/MaibornWolff/metric-gardener/blob/main/README.md), [UPDATE_GRAMMARS.md](https://github.com/MaibornWolff/metric-gardener/blob/main/UPDATE_GRAMMARS.md)) has been updated

