### PR TITLE
Fix: command import-grammars works now again

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,7 @@ yargs(hideBin(process.argv))
         "import-grammars",
         "(re-)import grammar expression types for supported languages",
         {},
-        (argv) => {
+        (_argv) => {
             updateNodeTypesMappingFile();
         },
     )

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,9 @@ yargs(hideBin(process.argv))
         "import-grammars",
         "(re-)import grammar expression types for supported languages",
         {},
-        updateNodeTypesMappingFile,
+        (argv) => {
+            updateNodeTypesMappingFile();
+        },
     )
     .command(
         "parse [sources-path]",


### PR DESCRIPTION
# Fix: command import-grammars works now again

Closes #223

## Description

`import-grammars` now works again after encapsulating the asynchronous import script into a lambda function, just like with the main `parse` command.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
* [x]  All TODOs related to this PR have been closed
* [ ]  There are automated tests for newly written code and bug fixes
* [x]  All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
* [x]  Documentation ([README.md](https://github.com/MaibornWolff/metric-gardener/blob/main/README.md), [UPDATE_GRAMMARS.md](https://github.com/MaibornWolff/metric-gardener/blob/main/UPDATE_GRAMMARS.md)) has been updated
