### PR TITLE
Rework node types config, renamed "expression" to "node type"

### DIFF
--- a/src/parser/CouplingCalculator.ts
+++ b/src/parser/CouplingCalculator.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { ExpressionMetricMapping } from "./helper/Model";
+import { NodeTypeConfig } from "./helper/Model";
 import { Configuration } from "./Configuration";
 import { Coupling } from "./metrics/coupling/Coupling";
 import { NamespaceCollector } from "./resolver/NamespaceCollector";
@@ -26,7 +26,7 @@ export class CouplingCalculator {
         const nodeTypesJson = fs
             .readFileSync(fs.realpathSync("./src/parser/config/nodeTypesConfig.json"))
             .toString();
-        const allNodeTypes: ExpressionMetricMapping[] = JSON.parse(nodeTypesJson);
+        const allNodeTypes: NodeTypeConfig[] = JSON.parse(nodeTypesJson);
 
         this.namespaceCollector = new NamespaceCollector();
         this.publicAccessorCollector = new PublicAccessorCollector();

--- a/src/parser/MetricCalculator.ts
+++ b/src/parser/MetricCalculator.ts
@@ -4,7 +4,7 @@ import { Classes } from "./metrics/Classes";
 import { LinesOfCode } from "./metrics/LinesOfCode";
 import { CommentLines } from "./metrics/CommentLines";
 import { RealLinesOfCode } from "./metrics/RealLinesOfCode";
-import { ExpressionMetricMapping } from "./helper/Model";
+import { NodeTypeConfig } from "./helper/Model";
 import { Configuration } from "./Configuration";
 import {
     FileMetricResults,
@@ -40,8 +40,7 @@ export class MetricCalculator {
      */
     constructor(configuration: Configuration) {
         this.#config = configuration;
-        const allNodeTypes: ExpressionMetricMapping[] =
-            nodeTypesConfig as ExpressionMetricMapping[];
+        const allNodeTypes: NodeTypeConfig[] = nodeTypesConfig as NodeTypeConfig[];
 
         this.#sourceFileMetrics = [
             new Complexity(allNodeTypes),

--- a/src/parser/config/nodeTypesConfig.json
+++ b/src/parser/config/nodeTypesConfig.json
@@ -754,7 +754,7 @@
     },
     {
         "type_name": "catch_clause",
-        "category": "",
+        "category": "catch_block",
         "languages": ["cs", "java", "js", "php", "ts", "cpp", "tsx"]
     },
     {

--- a/src/parser/config/nodeTypesConfig.json
+++ b/src/parser/config/nodeTypesConfig.json
@@ -156,7 +156,7 @@
     },
     {
         "type_name": "conditional_expression",
-        "category": "conditional",
+        "category": "conditional_expression",
         "languages": ["cs", "php", "py", "cpp", "c"]
     },
     {
@@ -226,7 +226,7 @@
     },
     {
         "type_name": "is_expression",
-        "category": "conditional",
+        "category": "conditional_expression",
         "languages": ["cs"]
     },
     {
@@ -1029,7 +1029,7 @@
     },
     {
         "type_name": "switch_expression_arm",
-        "category": "conditional",
+        "category": "conditional_expression",
         "languages": ["cs"]
     },
     {
@@ -1691,7 +1691,7 @@
     },
     {
         "type_name": "ternary_expression",
-        "category": "conditional",
+        "category": "conditional_expression",
         "languages": ["java", "js", "ts", "tsx", "sh"]
     },
     {
@@ -2463,7 +2463,7 @@
     },
     {
         "type_name": "elvis_expression",
-        "category": "conditional",
+        "category": "conditional_expression",
         "languages": ["kt"]
     },
     {
@@ -3187,7 +3187,7 @@
     },
     {
         "type_name": "list",
-        "category": "conditional",
+        "category": "conditional_expression",
         "activated_for_languages": ["sh"],
         "languages": ["py", "sh"]
     },
@@ -3203,7 +3203,7 @@
     },
     {
         "type_name": "conditional_type",
-        "category": "conditional",
+        "category": "conditional_expression",
         "languages": ["ts", "tsx"]
     },
     {
@@ -3473,7 +3473,7 @@
     },
     {
         "type_name": "boolean_operator",
-        "category": "conditional",
+        "category": "conditional_expression",
         "languages": ["py"]
     },
     {
@@ -4278,7 +4278,7 @@
     },
     {
         "type_name": "and_pattern",
-        "category": "conditional",
+        "category": "conditional_expression",
         "languages": ["cs"]
     },
     {
@@ -4333,7 +4333,7 @@
     },
     {
         "type_name": "or_pattern",
-        "category": "conditional",
+        "category": "conditional_expression",
         "languages": ["cs", "rs"]
     },
     {

--- a/src/parser/config/nodeTypesConfig.json
+++ b/src/parser/config/nodeTypesConfig.json
@@ -1,373 +1,267 @@
 [
     {
-        "expression": "class_declaration",
-        "metrics": ["classes"],
-        "type": "statement",
-        "category": "",
+        "type_name": "class_declaration",
+        "category": "class_definition",
         "languages": ["cs", "java", "js", "kt", "php", "ts", "tsx"]
     },
     {
-        "expression": "constructor_declaration",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "constructor_declaration",
+        "category": "function",
         "languages": ["cs", "java"]
     },
     {
-        "expression": "conversion_operator_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "conversion_operator_declaration",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "delegate_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "delegate_declaration",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "destructor_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "destructor_declaration",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "enum_declaration",
-        "metrics": ["classes"],
-        "type": "statement",
-        "category": "",
+        "type_name": "enum_declaration",
+        "category": "enum_definition",
         "languages": ["cs", "java", "ts", "php", "tsx"]
     },
     {
-        "expression": "event_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "event_declaration",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "event_field_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "event_field_declaration",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "field_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "field_declaration",
         "category": "",
         "languages": ["cs", "go", "java", "cpp", "rs", "c"]
     },
     {
-        "expression": "indexer_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "indexer_declaration",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "interface_declaration",
-        "metrics": ["classes"],
-        "type": "statement",
-        "category": "",
+        "type_name": "interface_declaration",
+        "category": "interface_definition",
         "languages": ["cs", "java", "php", "ts", "tsx"]
     },
     {
-        "expression": "method_declaration",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "method_declaration",
+        "category": "function",
         "languages": ["cs", "go", "java", "php"]
     },
     {
-        "expression": "namespace_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_declaration",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "operator_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "operator_declaration",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "property_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "property_declaration",
         "category": "",
         "languages": ["cs", "kt", "php"]
     },
     {
-        "expression": "record_declaration",
-        "metrics": ["classes"],
-        "type": "statement",
-        "category": "",
+        "type_name": "record_declaration",
+        "category": "record_definition",
         "languages": ["cs", "java"]
     },
     {
-        "expression": "struct_declaration",
-        "metrics": ["classes"],
-        "type": "statement",
+        "type_name": "struct_declaration",
+        "category": "struct_definition",
+        "languages": ["cs"]
+    },
+    {
+        "type_name": "using_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "using_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "anonymous_method_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "anonymous_method_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "anonymous_object_creation_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "anonymous_object_creation_expression",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cs"]
-    },
-    {
-        "expression": "array_creation_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "array_creation_expression",
         "category": "",
         "languages": ["cs", "java", "php"]
     },
     {
-        "expression": "as_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "as_expression",
         "category": "",
         "languages": ["cs", "kt", "ts", "tsx"]
     },
     {
-        "expression": "assignment_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "assignment_expression",
         "category": "",
         "languages": ["cs", "java", "js", "php", "ts", "cpp", "tsx", "rs", "c"]
     },
     {
-        "expression": "await_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "await_expression",
         "category": "",
         "languages": ["cs", "js", "ts", "tsx", "rs"]
     },
     {
-        "expression": "base_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "base_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "binary_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression",
         "category": "",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"]
     },
     {
-        "expression": "boolean_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "boolean_literal",
         "category": "",
         "languages": ["cs", "kt", "rs"]
     },
     {
-        "expression": "cast_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "cast_expression",
         "category": "",
         "languages": ["cs", "java", "php", "cpp", "c"]
     },
     {
-        "expression": "character_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "character_literal",
         "category": "",
         "languages": ["cs", "java", "kt"]
     },
     {
-        "expression": "checked_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "checked_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "conditional_access_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "conditional_access_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "conditional_expression",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "conditional_expression",
+        "category": "conditional",
         "languages": ["cs", "php", "py", "cpp", "c"]
     },
     {
-        "expression": "default_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "default_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "element_access_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "element_access_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "element_binding_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "element_binding_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "generic_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "generic_name",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "global",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "global",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "identifier",
         "category": "",
         "languages": ["cs", "go", "java", "js", "kt", "ts", "py", "cpp", "tsx", "rb", "rs", "c"]
     },
     {
-        "expression": "implicit_array_creation_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "implicit_array_creation_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "implicit_object_creation_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "implicit_object_creation_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "implicit_stack_alloc_array_creation_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "implicit_stack_alloc_array_creation_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "initializer_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "initializer_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "integer_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "integer_literal",
         "category": "",
         "languages": ["cs", "kt", "rs"]
     },
     {
-        "expression": "interpolated_string_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "interpolated_string_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "invocation_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "invocation_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "is_expression",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "is_expression",
+        "category": "conditional",
+        "languages": ["cs"]
+    },
+    {
+        "type_name": "is_pattern_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "is_pattern_expression",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cs"]
-    },
-    {
-        "expression": "lambda_expression",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "lambda_expression",
+        "category": "function",
         "activated_for_languages": ["cs", "java"],
         "languages": ["cs", "java", "cpp"]
     },
     {
-        "expression": "make_ref_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "make_ref_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "member_access_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "member_access_expression",
         "category": "",
         "languages": ["cs", "php"]
     },
     {
-        "expression": "null_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "null_literal",
         "category": "",
         "languages": ["cs", "java"]
     },
     {
-        "expression": "object_creation_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "object_creation_expression",
         "category": "",
         "languages": ["cs", "java", "php"]
     },
     {
-        "expression": "parenthesized_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parenthesized_expression",
         "category": "",
         "languages": [
             "cs",
@@ -386,1162 +280,855 @@
         ]
     },
     {
-        "expression": "postfix_unary_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "postfix_unary_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "prefix_unary_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "prefix_unary_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "query_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "query_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "range_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "range_expression",
         "category": "",
         "languages": ["cs", "kt", "rs"]
     },
     {
-        "expression": "real_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "real_literal",
         "category": "",
         "languages": ["cs", "kt"]
     },
     {
-        "expression": "ref_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ref_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "ref_type_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ref_type_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "ref_value_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ref_value_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "size_of_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "size_of_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "stack_alloc_array_creation_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "stack_alloc_array_creation_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "string_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "string_literal",
         "category": "",
         "languages": ["cs", "java", "cpp", "kt", "rs", "c"]
     },
     {
-        "expression": "switch_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "switch_expression",
         "category": "",
         "languages": ["cs", "java"]
     },
     {
-        "expression": "this_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "this_expression",
         "category": "",
         "languages": ["cs", "kt"]
     },
     {
-        "expression": "throw_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "throw_expression",
         "category": "",
         "languages": ["cs", "php"]
     },
     {
-        "expression": "tuple_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "tuple_expression",
         "category": "",
         "languages": ["cs", "rs"]
     },
     {
-        "expression": "type_of_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_of_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "verbatim_string_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "verbatim_string_literal",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "with_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "with_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "block",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "block",
         "category": "",
         "languages": ["cs", "go", "java", "py", "rb", "rs"]
     },
     {
-        "expression": "break_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "break_statement",
         "category": "",
         "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx", "c"]
     },
     {
-        "expression": "checked_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "checked_statement",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "continue_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "continue_statement",
         "category": "",
         "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx", "c"]
     },
     {
-        "expression": "do_statement",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "do_statement",
+        "category": "loop",
         "languages": ["cs", "java", "js", "php", "ts", "cpp", "tsx", "c"]
     },
     {
-        "expression": "empty_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "empty_statement",
         "category": "",
         "languages": ["cs", "go", "js", "php", "ts", "tsx", "rb", "rs"]
     },
     {
-        "expression": "expression_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "expression_statement",
         "category": "",
         "languages": ["cs", "java", "js", "php", "ts", "py", "cpp", "go", "tsx", "rs", "c"]
     },
     {
-        "expression": "fixed_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "fixed_statement",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "for_each_statement",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "for_each_statement",
+        "category": "loop",
         "languages": ["cs"]
     },
     {
-        "expression": "for_statement",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "for_statement",
+        "category": "loop",
         "languages": ["cs", "go", "java", "js", "kt", "php", "ts", "py", "cpp", "tsx", "sh", "c"]
     },
     {
-        "expression": "goto_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "goto_statement",
         "category": "",
         "languages": ["cs", "go", "php", "cpp", "c"]
     },
     {
-        "expression": "if_statement",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "if_statement",
+        "category": "if",
         "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx", "sh", "c"]
     },
     {
-        "expression": "labeled_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "labeled_statement",
         "category": "",
         "languages": ["cs", "go", "java", "js", "ts", "cpp", "tsx", "c"]
     },
     {
-        "expression": "local_declaration_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "local_declaration_statement",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "local_function_statement",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
+        "type_name": "local_function_statement",
+        "category": "function",
+        "languages": ["cs"]
+    },
+    {
+        "type_name": "lock_statement",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "lock_statement",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cs"]
-    },
-    {
-        "expression": "return_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "return_statement",
         "category": "",
         "languages": ["cs", "go", "java", "js", "php", "ts", "py", "cpp", "tsx", "c"]
     },
     {
-        "expression": "switch_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "switch_statement",
         "category": "",
         "languages": ["cs", "js", "php", "ts", "cpp", "tsx", "c"]
     },
     {
-        "expression": "throw_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "throw_statement",
         "category": "",
         "languages": ["cs", "java", "js", "ts", "cpp", "tsx"]
     },
     {
-        "expression": "try_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "try_statement",
         "category": "",
         "languages": ["cs", "java", "js", "php", "ts", "py", "cpp", "tsx"]
     },
     {
-        "expression": "unsafe_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unsafe_statement",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "using_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "using_statement",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "while_statement",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "while_statement",
+        "category": "loop",
         "languages": ["cs", "java", "js", "kt", "php", "ts", "py", "cpp", "tsx", "sh", "c"]
     },
     {
-        "expression": "yield_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "yield_statement",
         "category": "",
         "languages": ["cs", "java"]
     },
     {
-        "expression": "alias_qualified_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "alias_qualified_name",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "array_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "array_type",
         "category": "",
         "languages": ["cs", "go", "java", "ts", "tsx", "rs"]
     },
     {
-        "expression": "function_pointer_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "function_pointer_type",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "implicit_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "implicit_type",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "nullable_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "nullable_type",
         "category": "",
         "languages": ["cs", "kt"]
     },
     {
-        "expression": "pointer_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "pointer_type",
         "category": "",
         "languages": ["cs", "go", "rs"]
     },
     {
-        "expression": "predefined_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "predefined_type",
         "category": "",
         "languages": ["cs", "ts", "tsx"]
     },
     {
-        "expression": "qualified_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "qualified_name",
         "category": "",
         "languages": ["cs", "php"]
     },
     {
-        "expression": "tuple_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "tuple_type",
         "category": "",
         "languages": ["cs", "ts", "tsx", "rs"]
     },
     {
-        "expression": "accessor_declaration",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
+        "type_name": "accessor_declaration",
+        "category": "function",
+        "languages": ["cs"]
+    },
+    {
+        "type_name": "accessor_list",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "accessor_list",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cs"]
-    },
-    {
-        "expression": "argument",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "argument",
         "category": "",
         "languages": ["cs", "php"]
     },
     {
-        "expression": "argument_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "argument_list",
         "category": "",
         "languages": ["cs", "go", "java", "py", "cpp", "rb", "c"]
     },
     {
-        "expression": "array_rank_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "array_rank_specifier",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "arrow_expression_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "arrow_expression_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "assignment_operator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "assignment_operator",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "attribute",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "attribute",
         "category": "",
         "languages": ["cs", "py", "cpp", "php", "rs", "c"]
     },
     {
-        "expression": "attribute_argument",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "attribute_argument",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "attribute_argument_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "attribute_argument_list",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "attribute_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "attribute_list",
         "category": "",
         "languages": ["cs", "php"]
     },
     {
-        "expression": "attribute_target_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "attribute_target_specifier",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "base_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "base_list",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "binary_expression_!=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_!=",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "!="
     },
     {
-        "expression": "binary_expression_%",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_%",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "%"
     },
     {
-        "expression": "binary_expression_&",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_&",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "&"
     },
     {
-        "expression": "binary_expression_&&",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "binary_expression",
+        "type_name": "binary_expression_&&",
+        "category": "logical_binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "&&"
     },
     {
-        "expression": "binary_expression_*",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_*",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "*"
     },
     {
-        "expression": "binary_expression_+",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_+",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "+"
     },
     {
-        "expression": "binary_expression_-",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_-",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "-"
     },
     {
-        "expression": "binary_expression_/",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_/",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "/"
     },
     {
-        "expression": "binary_expression_<",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_<",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "<"
     },
     {
-        "expression": "binary_expression_<<",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_<<",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "<<"
     },
     {
-        "expression": "binary_expression_<=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_<=",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "<="
     },
     {
-        "expression": "binary_expression_==",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_==",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "=="
     },
     {
-        "expression": "binary_expression_>",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_>",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": ">"
     },
     {
-        "expression": "binary_expression_>=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_>=",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": ">="
     },
     {
-        "expression": "binary_expression_>>",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_>>",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": ">>"
     },
     {
-        "expression": "binary_expression_??",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "binary_expression",
+        "type_name": "binary_expression_??",
+        "category": "logical_binary_expression",
         "languages": ["cs", "js", "ts", "php", "tsx"],
+        "grammar_type_name": "binary_expression",
         "operator": "??"
     },
     {
-        "expression": "binary_expression_^",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_^",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "^"
     },
     {
-        "expression": "binary_expression_|",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_|",
         "category": "binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "|"
     },
     {
-        "expression": "binary_expression_||",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "binary_expression",
+        "type_name": "binary_expression_||",
+        "category": "logical_binary_expression",
         "languages": ["cs", "go", "java", "js", "php", "ts", "cpp", "tsx", "rs", "sh", "c"],
+        "grammar_type_name": "binary_expression",
         "operator": "||"
     },
     {
-        "expression": "bracketed_argument_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "bracketed_argument_list",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "bracketed_parameter_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "bracketed_parameter_list",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "case_pattern_switch_label",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "case_pattern_switch_label",
         "category": "case_label",
         "languages": ["cs"]
     },
     {
-        "expression": "case_switch_label",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "case_switch_label",
         "category": "case_label",
         "languages": ["cs"]
     },
     {
-        "expression": "catch_clause",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "catch_clause",
         "category": "",
         "languages": ["cs", "java", "js", "php", "ts", "cpp", "tsx"]
     },
     {
-        "expression": "catch_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "catch_declaration",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "catch_filter_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "catch_filter_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "compilation_unit",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "compilation_unit",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "constant_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "constant_pattern",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "constructor_constraint",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "constructor_constraint",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "constructor_initializer",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "constructor_initializer",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "declaration_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "declaration_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "declaration_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "declaration_list",
         "category": "",
         "languages": ["cs", "php", "cpp", "rs", "c"]
     },
     {
-        "expression": "declaration_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "declaration_pattern",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "default_switch_label",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "default_switch_label",
         "category": "default_label",
         "languages": ["cs"]
     },
     {
-        "expression": "enum_member_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_member_declaration",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "enum_member_declaration_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_member_declaration_list",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "equals_value_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "equals_value_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "explicit_interface_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "explicit_interface_specifier",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "extern_alias_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "extern_alias_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "finally_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "finally_clause",
         "category": "",
         "languages": ["cs", "java", "js", "php", "ts", "py", "tsx"]
     },
     {
-        "expression": "from_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "from_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "function_pointer_calling_convention",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "function_pointer_calling_convention",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "function_pointer_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "function_pointer_parameter",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "function_pointer_unmanaged_calling_convention",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "function_pointer_unmanaged_calling_convention",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "function_pointer_unmanaged_calling_convention_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "function_pointer_unmanaged_calling_convention_list",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "global_attribute_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "global_attribute_list",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "global_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "global_statement",
         "category": "",
         "languages": ["cs", "py"]
     },
     {
-        "expression": "group_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "group_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "interpolated_string_text",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "interpolated_string_text",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "interpolated_verbatim_string_text",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "interpolated_verbatim_string_text",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "interpolation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "interpolation",
         "category": "",
         "languages": ["cs", "py", "rb"]
     },
     {
-        "expression": "interpolation_alignment_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "interpolation_alignment_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "interpolation_format_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "interpolation_format_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "join_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "join_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "join_into_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "join_into_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "label_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "label_name",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "let_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "let_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "member_binding_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "member_binding_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "modifier",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "name_colon",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "name_colon",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "name_equals",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "name_equals",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "negated_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "negated_pattern",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "order_by_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "order_by_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parameter",
         "category": "",
         "languages": ["cs", "kt", "rs"]
     },
     {
-        "expression": "parameter_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parameter_list",
         "category": "",
         "languages": ["cs", "go", "cpp", "c"]
     },
     {
-        "expression": "parameter_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parameter_modifier",
         "category": "",
         "languages": ["cs", "kt"]
     },
     {
-        "expression": "parenthesized_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parenthesized_pattern",
         "category": "",
         "languages": ["cs", "rb"]
     },
     {
-        "expression": "parenthesized_variable_designation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parenthesized_variable_designation",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "positional_pattern_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "positional_pattern_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "primary_constructor_base_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "primary_constructor_base_type",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "property_pattern_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "property_pattern_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "query_continuation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "query_continuation",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "recursive_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "recursive_pattern",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "relational_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "relational_pattern",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "select_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "select_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "simple_assignment_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "simple_assignment_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "subpattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "subpattern",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "switch_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "switch_body",
         "category": "",
         "languages": ["cs", "js", "ts", "tsx"]
     },
     {
-        "expression": "switch_expression_arm",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "switch_expression_arm",
+        "category": "conditional",
+        "languages": ["cs"]
+    },
+    {
+        "type_name": "switch_section",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "switch_section",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "tuple_element",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "tuple_element",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cs"]
-    },
-    {
-        "expression": "tuple_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "tuple_pattern",
         "category": "",
         "languages": ["cs", "py", "rs"]
     },
     {
-        "expression": "type_argument_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_argument_list",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "type_constraint",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_constraint",
         "category": "",
         "languages": ["cs", "kt"]
     },
     {
-        "expression": "type_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_parameter",
         "category": "",
         "languages": ["cs", "java", "kt", "ts", "py", "tsx"]
     },
     {
-        "expression": "type_parameter_constraint",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_parameter_constraint",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "type_parameter_constraints_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_parameter_constraints_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "type_parameter_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_parameter_list",
         "category": "",
         "languages": ["cs", "go"]
     },
     {
-        "expression": "type_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_pattern",
         "category": "",
         "languages": ["cs", "java"]
     },
     {
-        "expression": "var_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "var_pattern",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "variable_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variable_declaration",
         "category": "",
         "languages": ["cs", "js", "kt", "ts", "tsx"]
     },
     {
-        "expression": "variable_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variable_declarator",
         "category": "",
         "languages": ["cs", "java", "js", "ts", "tsx"]
     },
     {
-        "expression": "when_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "when_clause",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "where_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "where_clause",
         "category": "",
         "languages": ["cs", "rs"]
     },
     {
-        "expression": "with_initializer_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "with_initializer_expression",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": ";",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": ";",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "await",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "await",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "class",
-        "metrics": ["classes"],
-        "type": "statement",
-        "category": "",
+        "type_name": "class",
+        "category": "class_definition",
         "languages": ["js", "ts", "tsx", "rb"]
     },
     {
-        "expression": "comment",
-        "metrics": ["comment_lines", "real_lines_of_code"],
-        "type": "statement",
+        "type_name": "comment",
         "category": "comment",
         "languages": [
             "cs",
@@ -1560,16 +1147,12 @@
         ]
     },
     {
-        "expression": "discard",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "discard",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "escape_sequence",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "escape_sequence",
         "category": "",
         "languages": [
             "cs",
@@ -1589,7507 +1172,5405 @@
         ]
     },
     {
-        "expression": "false",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "false",
         "category": "",
         "languages": ["go", "java", "js", "ts", "py", "cpp", "tsx", "rb", "c", "json"]
     },
     {
-        "expression": "module",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "module",
         "category": "",
         "activated_for_languages": ["py"],
         "languages": ["ts", "py", "tsx", "rb"]
     },
     {
-        "expression": "set",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "set",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "this",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "this",
         "category": "",
         "languages": ["java", "js", "ts", "cpp", "tsx"]
     },
     {
-        "expression": "true",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "true",
         "category": "",
         "languages": ["go", "java", "js", "ts", "py", "cpp", "tsx", "rb", "c", "json"]
     },
     {
-        "expression": "type",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "type",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "virtual",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "virtual",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "void_keyword",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "void_keyword",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "yield",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "yield",
         "category": "",
         "languages": ["py", "rb"]
     },
     {
-        "expression": "call_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "call_expression",
         "category": "",
         "languages": ["go", "js", "kt", "ts", "cpp", "tsx", "rs", "c"]
     },
     {
-        "expression": "composite_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "composite_literal",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "float_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "float_literal",
         "category": "",
         "languages": ["go", "rs"]
     },
     {
-        "expression": "func_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "func_literal",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "imaginary_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "imaginary_literal",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "index_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "index_expression",
         "category": "",
         "languages": ["go", "rs"]
     },
     {
-        "expression": "int_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "int_literal",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "interpreted_string_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "interpreted_string_literal",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "nil",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "nil",
         "category": "",
         "languages": ["go", "rb"]
     },
     {
-        "expression": "raw_string_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "raw_string_literal",
         "category": "",
         "languages": ["go", "cpp", "rs"]
     },
     {
-        "expression": "rune_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "rune_literal",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "selector_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "selector_expression",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "slice_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "slice_expression",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "type_assertion_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_assertion_expression",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "type_conversion_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_conversion_expression",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "unary_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unary_expression",
         "category": "",
         "languages": ["go", "java", "js", "ts", "cpp", "tsx", "rs", "sh", "c"]
     },
     {
-        "expression": "_simple_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_simple_statement",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "assignment_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "assignment_statement",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "dec_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dec_statement",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "inc_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "inc_statement",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "send_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "send_statement",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "short_var_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "short_var_declaration",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "_simple_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_simple_type",
         "category": "",
         "languages": ["go", "java"]
     },
     {
-        "expression": "channel_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "channel_type",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "function_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "function_type",
         "category": "",
         "languages": ["go", "kt", "ts", "tsx", "rs"]
     },
     {
-        "expression": "interface_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "interface_type",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "map_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "map_type",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "qualified_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "qualified_type",
         "category": "",
         "languages": ["go", "rs"]
     },
     {
-        "expression": "slice_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "slice_type",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "struct_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "struct_type",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "type_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_identifier",
         "category": "",
         "languages": ["go", "java", "kt", "ts", "cpp", "tsx", "rs", "c"]
     },
     {
-        "expression": "const_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "const_declaration",
         "category": "",
         "languages": ["go", "php"]
     },
     {
-        "expression": "defer_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "defer_statement",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "expression_switch_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "expression_switch_statement",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "fallthrough_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "fallthrough_statement",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "go_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "go_statement",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "select_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "select_statement",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "type_declaration",
-        "metrics": ["classes"],
-        "type": "statement",
+        "type_name": "type_declaration",
+        "category": "interface_definition",
+        "languages": ["go"]
+    },
+    {
+        "type_name": "type_switch_statement",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "type_switch_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "var_declaration",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "var_declaration",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["go"]
-    },
-    {
-        "expression": "parenthesized_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parenthesized_type",
         "category": "",
         "languages": ["go", "kt", "ts", "tsx"]
     },
     {
-        "expression": "binary_expression_&^",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_&^",
         "category": "binary_expression",
         "languages": ["go"],
+        "grammar_type_name": "binary_expression",
         "operator": "&^"
     },
     {
-        "expression": "communication_case",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "communication_case",
         "category": "case_label",
         "languages": ["go"]
     },
     {
-        "expression": "const_spec",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "const_spec",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "default_case",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "default_case",
         "category": "default_label",
         "languages": ["go"]
     },
     {
-        "expression": "dot",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dot",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "expression_case",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "expression_case",
         "category": "case_label",
         "languages": ["go"]
     },
     {
-        "expression": "expression_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "expression_list",
         "category": "",
         "languages": ["go", "py"]
     },
     {
-        "expression": "field_declaration_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "field_declaration_list",
         "category": "",
         "languages": ["go", "cpp", "rs", "c"]
     },
     {
-        "expression": "for_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "for_clause",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "function_declaration",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "function_declaration",
+        "category": "function",
         "languages": ["go", "js", "kt", "ts", "tsx"]
     },
     {
-        "expression": "implicit_length_array_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "implicit_length_array_type",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "import_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "import_declaration",
         "category": "",
         "languages": ["go", "java"]
     },
     {
-        "expression": "import_spec",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "import_spec",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "import_spec_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "import_spec_list",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "keyed_element",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "keyed_element",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "literal_value",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "literal_value",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "method_spec",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "method_spec",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "package_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "package_clause",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "parameter_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parameter_declaration",
         "category": "",
         "languages": ["go", "cpp", "c"]
     },
     {
-        "expression": "range_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "range_clause",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "receive_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "receive_statement",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "source_file",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "source_file",
         "category": "",
         "languages": ["go", "kt", "rs"]
     },
     {
-        "expression": "type_alias",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_alias",
         "category": "",
         "languages": ["go", "kt"]
     },
     {
-        "expression": "type_case",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "type_case",
         "category": "case_label",
         "languages": ["go"]
     },
     {
-        "expression": "type_spec",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_spec",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "var_spec",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "var_spec",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "variadic_argument",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variadic_argument",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "variadic_parameter_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variadic_parameter_declaration",
         "category": "",
         "languages": ["go", "cpp"]
     },
     {
-        "expression": "blank_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "blank_identifier",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "field_identifier",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "field_identifier",
         "category": "",
         "languages": ["go", "cpp", "rs", "c"]
     },
     {
-        "expression": "import",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "import",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "package_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "package_identifier",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_literal",
         "category": "",
         "languages": ["java", "php", "rs"]
     },
     {
-        "expression": "binary_integer_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_integer_literal",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "decimal_floating_point_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "decimal_floating_point_literal",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "decimal_integer_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "decimal_integer_literal",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "hex_floating_point_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "hex_floating_point_literal",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "hex_integer_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "hex_integer_literal",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "octal_integer_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "octal_integer_literal",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "boolean_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "boolean_type",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "floating_point_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "floating_point_type",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "generic_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "generic_type",
         "category": "",
         "languages": ["java", "ts", "go", "py", "tsx", "rs"]
     },
     {
-        "expression": "integral_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "integral_type",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "scoped_type_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "scoped_type_identifier",
         "category": "",
         "languages": ["java", "rs"]
     },
     {
-        "expression": "void_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "void_type",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "_unannotated_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_unannotated_type",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "annotated_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "annotated_type",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "declaration",
         "category": "",
         "languages": ["java", "js", "ts", "cpp", "tsx", "c"]
     },
     {
-        "expression": "annotation_type_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "annotation_type_declaration",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "module_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "module_declaration",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "package_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "package_declaration",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "instanceof_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "instanceof_expression",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "primary_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "primary_expression",
         "category": "",
         "languages": ["java", "js", "ts", "py", "tsx"]
     },
     {
-        "expression": "ternary_expression",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "ternary_expression",
+        "category": "conditional",
         "languages": ["java", "js", "ts", "tsx", "sh"]
     },
     {
-        "expression": "update_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "update_expression",
         "category": "",
         "languages": ["java", "js", "php", "ts", "cpp", "tsx", "c"]
     },
     {
-        "expression": "array_access",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "array_access",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "class_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "class_literal",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "field_access",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "field_access",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "method_invocation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "method_invocation",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "method_reference",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "method_reference",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "assert_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "assert_statement",
         "category": "",
         "languages": ["java", "py"]
     },
     {
-        "expression": "enhanced_for_statement",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "enhanced_for_statement",
+        "category": "loop",
+        "languages": ["java"]
+    },
+    {
+        "type_name": "local_variable_declaration",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "local_variable_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "synchronized_statement",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "synchronized_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "try_with_resources_statement",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "try_with_resources_statement",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["java"]
-    },
-    {
-        "expression": "annotation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "annotation",
         "category": "",
         "languages": ["java", "kt"]
     },
     {
-        "expression": "annotation_argument_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "annotation_argument_list",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "annotation_type_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "annotation_type_body",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "annotation_type_element_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "annotation_type_element_declaration",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "array_initializer",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "array_initializer",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "asterisk",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "asterisk",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "binary_expression_>>>",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_>>>",
         "category": "binary_expression",
         "languages": ["java", "js", "ts", "tsx"],
+        "grammar_type_name": "binary_expression",
         "operator": ">>>"
     },
     {
-        "expression": "catch_formal_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "catch_formal_parameter",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "catch_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "catch_type",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "class_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "class_body",
         "category": "",
         "languages": ["java", "js", "kt", "ts", "tsx"]
     },
     {
-        "expression": "constant_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "constant_declaration",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "constructor_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "constructor_body",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "dimensions",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dimensions",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "dimensions_expr",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dimensions_expr",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "element_value_array_initializer",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "element_value_array_initializer",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "element_value_pair",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "element_value_pair",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "enum_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_body",
         "category": "",
         "languages": ["java", "ts", "tsx"]
     },
     {
-        "expression": "enum_body_declarations",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_body_declarations",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "enum_constant",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_constant",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "explicit_constructor_invocation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "explicit_constructor_invocation",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "extends_interfaces",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "extends_interfaces",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "formal_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "formal_parameter",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "formal_parameters",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "formal_parameters",
         "category": "",
         "languages": ["java", "js", "php", "ts", "tsx"]
     },
     {
-        "expression": "inferred_parameters",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "inferred_parameters",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "interface_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "interface_body",
         "category": "",
         "languages": ["java", "ts", "tsx"]
     },
     {
-        "expression": "marker_annotation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "marker_annotation",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "modifiers",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "modifiers",
         "category": "",
         "languages": ["java", "kt"]
     },
     {
-        "expression": "module_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "module_body",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "program",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "program",
         "category": "",
         "languages": ["java", "js", "php", "ts", "tsx", "rb", "sh"]
     },
     {
-        "expression": "receiver_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "receiver_parameter",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "requires_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "requires_modifier",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "resource",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "resource",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "resource_specification",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "resource_specification",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "scoped_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "scoped_identifier",
         "category": "",
         "languages": ["java", "rs"]
     },
     {
-        "expression": "spread_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "spread_parameter",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "static_initializer",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
+        "type_name": "static_initializer",
+        "category": "function",
+        "languages": ["java"]
+    },
+    {
+        "type_name": "super_interfaces",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "super_interfaces",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["java"]
-    },
-    {
-        "expression": "superclass",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "superclass",
         "category": "",
         "languages": ["java", "rb"]
     },
     {
-        "expression": "switch_block",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "switch_block",
         "category": "",
         "languages": ["java", "php"]
     },
     {
-        "expression": "switch_label",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "switch_label",
         "category": "case_label",
         "languages": ["java"]
     },
     {
-        "expression": "throws",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "throws",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "type_arguments",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_arguments",
         "category": "",
         "languages": ["java", "kt", "ts", "go", "tsx", "rs"]
     },
     {
-        "expression": "type_bound",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_bound",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "type_parameters",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_parameters",
         "category": "",
         "languages": ["java", "kt", "ts", "tsx", "rs"]
     },
     {
-        "expression": "wildcard",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "wildcard",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "float",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "float",
         "category": "",
         "languages": ["php", "py", "rb"]
     },
     {
-        "expression": "super",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "super",
         "category": "",
         "languages": ["java", "js", "ts", "tsx", "rb", "rs"]
     },
     {
-        "expression": "generator_function_declaration",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
+        "type_name": "generator_function_declaration",
+        "category": "function",
+        "languages": ["js", "ts", "tsx"]
+    },
+    {
+        "type_name": "lexical_declaration",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "lexical_declaration",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["js", "ts", "tsx"]
-    },
-    {
-        "expression": "augmented_assignment_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "augmented_assignment_expression",
         "category": "",
         "languages": ["js", "php", "ts", "tsx"]
     },
     {
-        "expression": "jsx_element",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "jsx_element",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "jsx_self_closing_element",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "jsx_self_closing_element",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "new_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "new_expression",
         "category": "",
         "languages": ["js", "ts", "cpp", "tsx"]
     },
     {
-        "expression": "yield_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "yield_expression",
         "category": "",
         "languages": ["js", "php", "ts", "tsx", "rs"]
     },
     {
-        "expression": "pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "pattern",
         "category": "",
         "languages": ["java", "rb"]
     },
     {
-        "expression": "array_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "array_pattern",
         "category": "",
         "languages": ["js", "ts", "tsx", "rb"]
     },
     {
-        "expression": "object_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "object_pattern",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "rest_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "rest_pattern",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "array",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "array",
         "category": "nesting",
         "languages": ["js", "ts", "tsx", "rb", "sh", "json"]
     },
     {
-        "expression": "arrow_function",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "arrow_function",
+        "category": "function",
         "languages": ["js", "ts", "php", "tsx"]
     },
     {
-        "expression": "generator_function",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
+        "type_name": "generator_function",
+        "category": "function",
+        "languages": ["js", "ts", "tsx"]
+    },
+    {
+        "type_name": "member_expression",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "member_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "meta_property",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "meta_property",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["js", "ts", "tsx"]
-    },
-    {
-        "expression": "null",
-        "metrics": [],
-        "type": "keyword",
+        "type_name": "null",
         "category": "",
         "languages": ["js", "php", "ts", "cpp", "tsx", "c", "json"]
     },
     {
-        "expression": "number",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "number",
         "category": "",
         "languages": ["js", "ts", "tsx", "sh", "json"]
     },
     {
-        "expression": "object",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "object",
         "category": "nesting",
         "languages": ["js", "ts", "tsx", "json"]
     },
     {
-        "expression": "regex",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "regex",
         "category": "",
         "languages": ["js", "ts", "tsx", "rb", "sh"]
     },
     {
-        "expression": "string",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "string",
         "category": "",
         "languages": ["js", "php", "ts", "py", "tsx", "rb", "sh", "json"]
     },
     {
-        "expression": "subscript_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "subscript_expression",
         "category": "",
         "languages": ["js", "php", "ts", "cpp", "tsx", "c"]
     },
     {
-        "expression": "template_string",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "template_string",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "undefined",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "undefined",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "debugger_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "debugger_statement",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "export_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "export_statement",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "for_in_statement",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "for_in_statement",
+        "category": "loop",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "import_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "import_statement",
         "category": "",
         "languages": ["js", "ts", "py", "tsx"]
     },
     {
-        "expression": "statement_block",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "statement_block",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "with_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "with_statement",
         "category": "",
         "languages": ["js", "ts", "py", "tsx"]
     },
     {
-        "expression": "arguments",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "arguments",
         "category": "",
         "languages": ["js", "php", "ts", "tsx", "rs"]
     },
     {
-        "expression": "assignment_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "assignment_pattern",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "binary_expression_!==",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_!==",
         "category": "binary_expression",
         "languages": ["js", "php", "ts", "tsx"],
+        "grammar_type_name": "binary_expression",
         "operator": "!=="
     },
     {
-        "expression": "binary_expression_**",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_**",
         "category": "binary_expression",
         "languages": ["js", "ts", "tsx", "php", "sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "**"
     },
     {
-        "expression": "binary_expression_===",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_===",
         "category": "binary_expression",
         "languages": ["js", "php", "ts", "tsx"],
+        "grammar_type_name": "binary_expression",
         "operator": "==="
     },
     {
-        "expression": "binary_expression_in",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_in",
         "category": "binary_expression",
         "languages": ["js", "ts", "tsx"],
+        "grammar_type_name": "binary_expression",
         "operator": "in"
     },
     {
-        "expression": "binary_expression_instanceof",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_instanceof",
         "category": "binary_expression",
         "languages": ["js", "php", "ts", "tsx"],
+        "grammar_type_name": "binary_expression",
         "operator": "instanceof"
     },
     {
-        "expression": "class_heritage",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "class_heritage",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "computed_property_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "computed_property_name",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "decorator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "decorator",
         "category": "",
         "languages": ["js", "ts", "py", "tsx"]
     },
     {
-        "expression": "else_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "else_clause",
         "category": "",
         "languages": ["js", "php", "ts", "py", "cpp", "tsx", "rs", "sh", "c"]
     },
     {
-        "expression": "export_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "export_clause",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "export_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "export_specifier",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "import_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "import_clause",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "import_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "import_specifier",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "jsx_attribute",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "jsx_attribute",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "jsx_closing_element",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "jsx_closing_element",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "jsx_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "jsx_expression",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "jsx_namespace_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "jsx_namespace_name",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "jsx_opening_element",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "jsx_opening_element",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "method_definition",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
+        "type_name": "method_definition",
+        "category": "function",
+        "languages": ["js", "ts", "tsx"]
+    },
+    {
+        "type_name": "named_imports",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "named_imports",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_import",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "namespace_import",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["js", "ts", "tsx"]
-    },
-    {
-        "expression": "nested_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "nested_identifier",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "object_assignment_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "object_assignment_pattern",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "pair",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "pair",
         "category": "",
         "languages": ["js", "php", "ts", "py", "tsx", "rb", "json"]
     },
     {
-        "expression": "pair_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "pair_pattern",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "public_field_definition",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "public_field_definition",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "sequence_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "sequence_expression",
         "category": "",
         "languages": ["js", "php", "ts", "tsx"]
     },
     {
-        "expression": "spread_element",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "spread_element",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "switch_case",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "switch_case",
         "category": "case_label",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "switch_default",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "switch_default",
         "category": "default_label",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "template_substitution",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "template_substitution",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "hash_bang_line",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "hash_bang_line",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "jsx_text",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "jsx_text",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "property_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "property_identifier",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "regex_flags",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "regex_flags",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "regex_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "regex_pattern",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "shorthand_property_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "shorthand_property_identifier",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "shorthand_property_identifier_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "shorthand_property_identifier_pattern",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "statement_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "statement_identifier",
         "category": "",
         "languages": ["js", "ts", "cpp", "tsx", "c"]
     },
     {
-        "expression": "additive_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "additive_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "annotated_lambda",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "annotated_lambda",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "anonymous_function",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "anonymous_function",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "anonymous_initializer",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "anonymous_initializer",
+        "category": "function",
         "languages": ["kt"]
     },
     {
-        "expression": "assignment",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "assignment",
         "category": "",
         "languages": ["kt", "py", "rb"]
     },
     {
-        "expression": "call_suffix",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "call_suffix",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "callable_reference",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "callable_reference",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "catch_block",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "catch_block",
+        "category": "catch_block",
+        "languages": ["kt"]
+    },
+    {
+        "type_name": "check_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "check_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "class_modifier",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "class_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "class_parameter",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "class_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "collection_literal",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "collection_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "companion_object",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "companion_object",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "comparison_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "comparison_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "conjunction_expression",
+        "category": "conditional",
+        "languages": ["kt"]
+    },
+    {
+        "type_name": "constructor_delegation_call",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "conjunction_expression",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "constructor_invocation",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "constructor_delegation_call",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "control_structure_body",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "constructor_invocation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "delegation_specifier",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "control_structure_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "directly_assignable_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "delegation_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "disjunction_expression",
+        "category": "conditional",
+        "languages": ["kt"]
+    },
+    {
+        "type_name": "do_while_statement",
+        "category": "loop",
+        "languages": ["kt"]
+    },
+    {
+        "type_name": "elvis_expression",
+        "category": "conditional",
+        "languages": ["kt"]
+    },
+    {
+        "type_name": "enum_class_body",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "directly_assignable_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_entry",
+        "category": "enum_definition",
+        "languages": ["kt"]
+    },
+    {
+        "type_name": "equality_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "disjunction_expression",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "explicit_delegation",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "do_while_statement",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "file_annotation",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "elvis_expression",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "finally_block",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "enum_class_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "function_body",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "enum_entry",
-        "metrics": ["classes"],
-        "type": "statement",
+        "type_name": "function_modifier",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "equality_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "function_type_parameters",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "explicit_delegation",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["kt"]
-    },
-    {
-        "expression": "file_annotation",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["kt"]
-    },
-    {
-        "expression": "finally_block",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["kt"]
-    },
-    {
-        "expression": "function_body",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["kt"]
-    },
-    {
-        "expression": "function_modifier",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["kt"]
-    },
-    {
-        "expression": "function_type_parameters",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["kt"]
-    },
-    {
-        "expression": "if_expression",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "if_expression",
+        "category": "if",
         "languages": ["kt", "rs"]
     },
     {
-        "expression": "import_alias",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "import_alias",
         "category": "",
         "languages": ["kt", "ts", "tsx"]
     },
     {
-        "expression": "import_header",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "import_header",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "indexing_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "indexing_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "indexing_suffix",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "indexing_suffix",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "infix_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "infix_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "inheritance_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "inheritance_modifier",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "interpolated_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "interpolated_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "interpolated_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "interpolated_identifier",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "jump_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "jump_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "lambda_literal",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "lambda_literal",
+        "category": "function",
         "languages": ["kt"]
     },
     {
-        "expression": "lambda_parameters",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "lambda_parameters",
         "category": "",
         "languages": ["kt", "py", "rb"]
     },
     {
-        "expression": "long_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "long_literal",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "member_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "member_modifier",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "multiplicative_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "multiplicative_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "navigation_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "navigation_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "navigation_suffix",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "navigation_suffix",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "object_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "object_declaration",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "object_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "object_literal",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "package_header",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "package_header",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "parameter_modifiers",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parameter_modifiers",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "parameter_with_optional_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parameter_with_optional_type",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "parenthesized_user_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parenthesized_user_type",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "platform_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "platform_modifier",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "postfix_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "postfix_expression",
         "category": "",
         "languages": ["kt", "sh"]
     },
     {
-        "expression": "prefix_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "prefix_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "primary_constructor",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "primary_constructor",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "property_delegate",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "property_delegate",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "range_test",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "range_test",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "secondary_constructor",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "secondary_constructor",
+        "category": "function",
         "languages": ["kt"]
     },
     {
-        "expression": "setter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "setter",
         "category": "",
         "languages": ["kt", "rb"]
     },
     {
-        "expression": "shebang_line",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "shebang_line",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "simple_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "simple_identifier",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "spread_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "spread_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "statements",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "statements",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "super_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "super_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "try_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "try_expression",
         "category": "",
         "languages": ["kt", "rs"]
     },
     {
-        "expression": "type_constraints",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_constraints",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "type_modifiers",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_modifiers",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "type_parameter_modifiers",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_parameter_modifiers",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "type_projection",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_projection",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "type_projection_modifiers",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_projection_modifiers",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "type_test",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_test",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "unsigned_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unsigned_literal",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "use_site_target",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "use_site_target",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "user_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "user_type",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "value_argument",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "value_argument",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "value_arguments",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "value_arguments",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "variance_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variance_modifier",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "visibility_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "visibility_modifier",
         "category": "",
         "languages": ["kt", "php", "rs"]
     },
     {
-        "expression": "when_condition",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "when_condition",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "when_entry",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "when_entry",
         "category": "case_label",
         "languages": ["kt"]
     },
     {
-        "expression": "when_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "when_expression",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "when_subject",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "when_subject",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "bin_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "bin_literal",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "hex_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "hex_literal",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "label",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "label",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "property_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "property_modifier",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "reification_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "reification_modifier",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "_primary_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_primary_expression",
         "category": "",
         "languages": ["php", "sh"]
     },
     {
-        "expression": "clone_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "clone_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "include_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "include_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "include_once_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "include_once_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "require_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "require_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "require_once_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "require_once_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "unary_op_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unary_op_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "boolean",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "boolean",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "heredoc",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "heredoc",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "integer",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "integer",
         "category": "",
         "languages": ["php", "py", "rb"]
     },
     {
-        "expression": "anonymous_function_creation_expression",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
+        "type_name": "anonymous_function_creation_expression",
+        "category": "function",
+        "languages": ["php"]
+    },
+    {
+        "type_name": "class_constant_access_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "class_constant_access_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dynamic_variable_name",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "dynamic_variable_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "function_call_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "function_call_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "member_call_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "member_call_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "print_intrinsic",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "print_intrinsic",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "scoped_call_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "scoped_call_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "scoped_property_access_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "scoped_property_access_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "shell_command_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "shell_command_expression",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["php"]
-    },
-    {
-        "expression": "variable_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variable_name",
         "category": "",
         "languages": ["php", "sh"]
     },
     {
-        "expression": "compound_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "compound_statement",
         "category": "",
         "languages": ["php", "cpp", "sh", "c"]
     },
     {
-        "expression": "declare_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "declare_statement",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "echo_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "echo_statement",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "foreach_statement",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "foreach_statement",
+        "category": "loop",
         "languages": ["php"]
     },
     {
-        "expression": "function_definition",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "function_definition",
+        "category": "function",
         "activated_for_languages": ["php", "py", "sh"],
         "languages": ["php", "py", "cpp", "sh", "c"]
     },
     {
-        "expression": "function_static_declaration",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
+        "type_name": "function_static_declaration",
+        "category": "function",
+        "languages": ["php"]
+    },
+    {
+        "type_name": "global_declaration",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "global_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "named_label_statement",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "named_label_statement",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["php"]
-    },
-    {
-        "expression": "namespace_definition",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_definition",
         "category": "",
         "languages": ["php", "cpp"]
     },
     {
-        "expression": "namespace_use_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_use_declaration",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "trait_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "trait_declaration",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "unset_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unset_statement",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "optional_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "optional_type",
         "category": "",
         "languages": ["php", "ts", "tsx"]
     },
     {
-        "expression": "primitive_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "primitive_type",
         "category": "",
         "languages": ["php", "cpp", "rs", "c"]
     },
     {
-        "expression": "anonymous_function_use_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "anonymous_function_use_clause",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "array_element_initializer",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "array_element_initializer",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "base_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "base_clause",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "binary_expression_.",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_.",
         "category": "binary_expression",
         "languages": ["php"],
+        "grammar_type_name": "binary_expression",
         "operator": "."
     },
     {
-        "expression": "binary_expression_<=>",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_<=>",
         "category": "binary_expression",
         "languages": ["php", "cpp"],
+        "grammar_type_name": "binary_expression",
         "operator": "<=>"
     },
     {
-        "expression": "binary_expression_<>",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_<>",
         "category": "binary_expression",
         "languages": ["php"],
+        "grammar_type_name": "binary_expression",
         "operator": "<>"
     },
     {
-        "expression": "binary_expression_and",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "binary_expression",
+        "type_name": "binary_expression_and",
+        "category": "logical_binary_expression",
         "languages": ["php", "cpp"],
+        "grammar_type_name": "binary_expression",
         "operator": "and"
     },
     {
-        "expression": "binary_expression_or",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "binary_expression",
+        "type_name": "binary_expression_or",
+        "category": "logical_binary_expression",
         "languages": ["php", "cpp"],
+        "grammar_type_name": "binary_expression",
         "operator": "or"
     },
     {
-        "expression": "binary_expression_xor",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "binary_expression",
+        "type_name": "binary_expression_xor",
+        "category": "logical_binary_expression",
         "languages": ["php", "cpp"],
+        "grammar_type_name": "binary_expression",
         "operator": "xor"
     },
     {
-        "expression": "case_statement",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "case_statement",
         "category": "case_label",
         "activated_for_languages": ["php", "cpp", "c"],
         "languages": ["php", "cpp", "sh", "c"]
     },
     {
-        "expression": "cast_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "cast_type",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "class_interface_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "class_interface_clause",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "colon_block",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "colon_block",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "const_element",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "const_element",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "declare_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "declare_directive",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "default_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "default_statement",
         "category": "default_label",
         "languages": ["php"]
     },
     {
-        "expression": "else_if_clause",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "else_if_clause",
+        "category": "if",
+        "languages": ["php"]
+    },
+    {
+        "type_name": "list_literal",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "list_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "name",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_aliasing_clause",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "namespace_aliasing_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_name",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "namespace_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_name_as_prefix",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "namespace_name_as_prefix",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_use_clause",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "namespace_use_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_use_group",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "namespace_use_group",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_use_group_clause",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "namespace_use_group_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "property_element",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "property_element",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "property_initializer",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "property_initializer",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "relative_scope",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "relative_scope",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "simple_parameter",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "simple_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "static_modifier",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "static_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "static_variable_declaration",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "static_variable_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "text",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "text",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "text_interpolation",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "text_interpolation",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["php"]
-    },
-    {
-        "expression": "use_as_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "use_as_clause",
         "category": "",
         "languages": ["php", "rs"]
     },
     {
-        "expression": "use_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "use_declaration",
         "category": "",
         "languages": ["php", "rs"]
     },
     {
-        "expression": "use_instead_of_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "use_instead_of_clause",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "use_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "use_list",
         "category": "",
         "languages": ["php", "rs"]
     },
     {
-        "expression": "variadic_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variadic_parameter",
         "category": "",
         "languages": ["php", "cpp", "rs", "c"]
     },
     {
-        "expression": "variadic_unpacking",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variadic_unpacking",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "list",
-        "metrics": ["complexity"],
-        "type": "keyword",
-        "category": "",
+        "type_name": "list",
+        "category": "conditional",
         "activated_for_languages": ["sh"],
         "languages": ["py", "sh"]
     },
     {
-        "expression": "php_tag",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "php_tag",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "var_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "var_modifier",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "conditional_type",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "conditional_type",
+        "category": "conditional",
+        "languages": ["ts", "tsx"]
+    },
+    {
+        "type_name": "existential_type",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "existential_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "flow_maybe_type",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "flow_maybe_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "index_type_query",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "index_type_query",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "literal_type",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "literal_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "lookup_type",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "lookup_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "nested_type_identifier",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "nested_type_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "object_type",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "object_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_query",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "type_query",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "abstract_class_declaration",
+        "category": "class_definition",
+        "languages": ["ts", "tsx"]
+    },
+    {
+        "type_name": "ambient_declaration",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "abstract_class_declaration",
-        "metrics": ["classes"],
-        "type": "statement",
+        "type_name": "function_signature",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "ambient_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "internal_module",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "function_signature",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_alias_declaration",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "internal_module",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["ts", "tsx"]
-    },
-    {
-        "expression": "type_alias_declaration",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["ts", "tsx"]
-    },
-    {
-        "expression": "type_assertion",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_assertion",
         "category": "",
         "languages": ["ts"]
     },
     {
-        "expression": "non_null_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "non_null_expression",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "abstract_method_signature",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "abstract_method_signature",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "accessibility_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "accessibility_modifier",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "asserts",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "asserts",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "call_signature",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "call_signature",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "constraint",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "constraint",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "construct_signature",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "construct_signature",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "constructor_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "constructor_type",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "default_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "default_type",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "enum_assignment",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_assignment",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "extends_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "extends_clause",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "implements_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "implements_clause",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "import_require_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "import_require_clause",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "index_signature",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "index_signature",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "infer_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "infer_type",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "intersection_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "intersection_type",
         "category": "",
         "languages": ["ts", "php", "tsx"]
     },
     {
-        "expression": "mapped_type_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "mapped_type_clause",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "method_signature",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "method_signature",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "omitting_type_annotation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "omitting_type_annotation",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "opting_type_annotation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "opting_type_annotation",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "optional_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "optional_parameter",
         "category": "",
         "languages": ["ts", "tsx", "rb"]
     },
     {
-        "expression": "property_signature",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "property_signature",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "readonly_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "readonly_type",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "required_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "required_parameter",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "rest_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "rest_type",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "type_annotation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_annotation",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "type_predicate",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_predicate",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "type_predicate_annotation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_predicate_annotation",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "union_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "union_type",
         "category": "",
         "languages": ["ts", "go", "php", "py", "tsx"]
     },
     {
-        "expression": "class_definition",
-        "metrics": ["classes"],
-        "type": "statement",
+        "type_name": "class_definition",
+        "category": "class_definition",
+        "languages": ["py"]
+    },
+    {
+        "type_name": "decorated_definition",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "decorated_definition",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "delete_statement",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "delete_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "exec_statement",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "exec_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "future_import_statement",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "future_import_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "import_from_statement",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "import_from_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "nonlocal_statement",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "nonlocal_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "pass_statement",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "pass_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "print_statement",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "print_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "raise_statement",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "raise_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "boolean_operator",
+        "category": "conditional",
+        "languages": ["py"]
+    },
+    {
+        "type_name": "comparison_operator",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "boolean_operator",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
-        "languages": ["py"]
-    },
-    {
-        "expression": "comparison_operator",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["py"]
-    },
-    {
-        "expression": "lambda",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "lambda",
+        "category": "function",
         "languages": ["py", "rb"]
     },
     {
-        "expression": "named_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "named_expression",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "not_operator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "not_operator",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "default_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "default_parameter",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "dictionary_splat_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dictionary_splat_pattern",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "list_splat_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "list_splat_pattern",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "typed_default_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "typed_default_parameter",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "typed_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "typed_parameter",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "list_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "list_pattern",
         "category": "",
         "languages": ["py", "cs"]
     },
     {
-        "expression": "subscript",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "subscript",
         "category": "",
         "languages": ["py", "sh"]
     },
     {
-        "expression": "binary_operator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_operator",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "call",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "call",
         "category": "",
         "languages": ["py", "rb"]
     },
     {
-        "expression": "concatenated_string",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "concatenated_string",
         "category": "",
         "languages": ["py", "cpp", "c"]
     },
     {
-        "expression": "dictionary",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dictionary",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "dictionary_comprehension",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dictionary_comprehension",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "ellipsis",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ellipsis",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "generator_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "generator_expression",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "list_comprehension",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "list_comprehension",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "none",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "none",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "set_comprehension",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "set_comprehension",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "tuple",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "tuple",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "unary_operator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unary_operator",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "aliased_import",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "aliased_import",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "augmented_assignment",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "augmented_assignment",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "chevron",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "chevron",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "dictionary_splat",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dictionary_splat",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "dotted_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dotted_name",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "elif_clause",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "elif_clause",
+        "category": "if",
         "languages": ["py", "sh"]
     },
     {
-        "expression": "except_clause",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "except_clause",
+        "category": "catch_block",
+        "languages": ["py"]
+    },
+    {
+        "type_name": "for_in_clause",
+        "category": "loop",
+        "languages": ["py"]
+    },
+    {
+        "type_name": "format_expression",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "for_in_clause",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "format_specifier",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "format_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "if_clause",
+        "category": "if",
+        "languages": ["py"]
+    },
+    {
+        "type_name": "import_prefix",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "format_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "keyword_argument",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "if_clause",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "list_splat",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "import_prefix",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["py"]
-    },
-    {
-        "expression": "keyword_argument",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["py"]
-    },
-    {
-        "expression": "list_splat",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["py"]
-    },
-    {
-        "expression": "parameters",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parameters",
         "category": "",
         "languages": ["py", "rs"]
     },
     {
-        "expression": "parenthesized_list_splat",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parenthesized_list_splat",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "pattern_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "pattern_list",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "relative_import",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "relative_import",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "slice",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "slice",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "wildcard_import",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "wildcard_import",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "with_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "with_clause",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "with_item",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "with_item",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "type_conversion",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_conversion",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "abstract_array_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "abstract_array_declarator",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "abstract_function_declarator",
-        "metrics": ["functions", "complexity"],
-        "type": "statement",
+        "type_name": "abstract_function_declarator",
+        "category": "function",
+        "languages": ["cpp", "c"]
+    },
+    {
+        "type_name": "abstract_parenthesized_declarator",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "abstract_parenthesized_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "abstract_pointer_declarator",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "abstract_pointer_declarator",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cpp", "c"]
-    },
-    {
-        "expression": "abstract_reference_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "abstract_reference_declarator",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "array_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "array_declarator",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "attributed_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "attributed_declarator",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "destructor_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "destructor_name",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "function_declarator",
-        "metrics": ["functions", "complexity"],
-        "type": "statement",
+        "type_name": "function_declarator",
+        "category": "function",
+        "languages": ["cpp", "c"]
+    },
+    {
+        "type_name": "operator_name",
+        "category": "",
+        "languages": ["cpp"]
+    },
+    {
+        "type_name": "parenthesized_declarator",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "operator_name",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cpp"]
-    },
-    {
-        "expression": "parenthesized_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "pointer_declarator",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "pointer_declarator",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cpp", "c"]
-    },
-    {
-        "expression": "qualified_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "qualified_identifier",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "reference_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "reference_declarator",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "structured_binding_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "structured_binding_declarator",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "template_function",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "template_function",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "char_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "char_literal",
         "category": "",
         "languages": ["cpp", "rs", "c"]
     },
     {
-        "expression": "co_await_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "co_await_expression",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "compound_literal_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "compound_literal_expression",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "delete_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "delete_expression",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "field_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "field_expression",
         "category": "",
         "languages": ["cpp", "rs", "c"]
     },
     {
-        "expression": "number_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "number_literal",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "parameter_pack_expansion",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parameter_pack_expansion",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "pointer_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "pointer_expression",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "sizeof_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "sizeof_expression",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "user_defined_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "user_defined_literal",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "template_method",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "template_method",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "co_return_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "co_return_statement",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "co_yield_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "co_yield_statement",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "for_range_loop",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "for_range_loop",
+        "category": "loop",
+        "languages": ["cpp"]
+    },
+    {
+        "type_name": "auto",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "auto",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "class_specifier",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "class_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "decltype",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "decltype",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dependent_type",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "dependent_type",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cpp"]
-    },
-    {
-        "expression": "enum_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_specifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "sized_type_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "sized_type_specifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "struct_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "struct_specifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "template_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "template_type",
         "category": "",
         "languages": ["cpp", "ts", "tsx"]
     },
     {
-        "expression": "union_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "union_specifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "access_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "access_specifier",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "alias_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "alias_declaration",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "attribute_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "attribute_declaration",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "attribute_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "attribute_specifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "attributed_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "attributed_statement",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "base_class_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "base_class_clause",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "bitfield_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "bitfield_clause",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "comma_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "comma_expression",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "condition_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "condition_clause",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "default_method_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "default_method_clause",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "delete_method_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "delete_method_clause",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "dependent_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dependent_name",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "enumerator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enumerator",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "enumerator_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enumerator_list",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "explicit_function_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "explicit_function_specifier",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "field_designator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "field_designator",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "field_initializer",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "field_initializer",
         "category": "",
         "languages": ["cpp", "rs"]
     },
     {
-        "expression": "field_initializer_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "field_initializer_list",
         "category": "",
         "languages": ["cpp", "rs"]
     },
     {
-        "expression": "friend_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "friend_declaration",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "init_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "init_declarator",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "initializer_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "initializer_list",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "initializer_pair",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "initializer_pair",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "lambda_capture_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "lambda_capture_specifier",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "lambda_default_capture",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "lambda_default_capture",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "linkage_specification",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "linkage_specification",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "ms_based_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ms_based_modifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "ms_call_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ms_call_modifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "ms_declspec_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ms_declspec_modifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "ms_pointer_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ms_pointer_modifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "ms_unaligned_ptr_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ms_unaligned_ptr_modifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "namespace_alias_definition",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_alias_definition",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "new_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "new_declarator",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "noexcept",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "noexcept",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "operator_cast",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "operator_cast",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "optional_parameter_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "optional_parameter_declaration",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "optional_type_parameter_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "optional_type_parameter_declaration",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "preproc_call",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_call",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "preproc_def",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_def",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "preproc_defined",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_defined",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "preproc_elif",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_elif",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "preproc_else",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_else",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "preproc_function_def",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_function_def",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "preproc_if",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_if",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "preproc_ifdef",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_ifdef",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "preproc_include",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_include",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "preproc_params",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_params",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "ref_qualifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ref_qualifier",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "static_assert_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "static_assert_declaration",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "storage_class_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "storage_class_specifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "subscript_designator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "subscript_designator",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "template_argument_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "template_argument_list",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "template_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "template_declaration",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "template_instantiation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "template_instantiation",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "template_parameter_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "template_parameter_list",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "template_template_parameter_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "template_template_parameter_declaration",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "throw_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "throw_specifier",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "trailing_return_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "trailing_return_type",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "translation_unit",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "translation_unit",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "type_definition",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_definition",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "type_descriptor",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_descriptor",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "type_parameter_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_parameter_declaration",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "type_qualifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_qualifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "using_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "using_declaration",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "variadic_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variadic_declarator",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "variadic_type_parameter_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variadic_type_parameter_declaration",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "virtual_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "virtual_specifier",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "literal_suffix",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "literal_suffix",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "ms_restrict_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ms_restrict_modifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "ms_signed_ptr_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ms_signed_ptr_modifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "ms_unsigned_ptr_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ms_unsigned_ptr_modifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "namespace_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_identifier",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "preproc_arg",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_arg",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "preproc_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_directive",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "system_lib_string",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "system_lib_string",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "record_struct_declaration",
-        "metrics": ["classes"],
-        "type": "statement",
+        "type_name": "record_struct_declaration",
+        "category": "record_definition",
+        "languages": ["cs"]
+    },
+    {
+        "type_name": "and_pattern",
+        "category": "conditional",
+        "languages": ["cs"]
+    },
+    {
+        "type_name": "define_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "and_pattern",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "elif_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "define_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "else_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "elif_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "endregion_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "else_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "error_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "endregion_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "expression_colon",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "error_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "file_scoped_namespace_declaration",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "expression_colon",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "if_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "file_scoped_namespace_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "line_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "if_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "nullable_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "line_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "or_pattern",
+        "category": "conditional",
+        "languages": ["cs", "rs"]
+    },
+    {
+        "type_name": "pragma_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "nullable_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "region_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "or_pattern",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "slice_pattern",
         "category": "",
         "languages": ["cs", "rs"]
     },
     {
-        "expression": "pragma_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "undef_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "region_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "warning_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "slice_pattern",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cs", "rs"]
-    },
-    {
-        "expression": "undef_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "endif_directive",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "warning_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_integer_literal",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "endif_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_message",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "preproc_integer_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_string_literal",
         "category": "",
         "languages": ["cs"]
     },
     {
-        "expression": "preproc_message",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cs"]
-    },
-    {
-        "expression": "preproc_string_literal",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cs"]
-    },
-    {
-        "expression": "iota",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "iota",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "negated_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "negated_type",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "literal_element",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "literal_element",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "struct_elem",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "struct_elem",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "struct_term",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "struct_term",
         "category": "",
         "languages": ["go"]
     },
     {
-        "expression": "block_comment",
-        "metrics": ["comment_lines", "real_lines_of_code"],
-        "type": "statement",
+        "type_name": "block_comment",
         "category": "comment",
         "languages": ["java", "rs"]
     },
     {
-        "expression": "line_comment",
-        "metrics": ["comment_lines", "real_lines_of_code"],
-        "type": "statement",
+        "type_name": "line_comment",
         "category": "comment",
         "languages": ["java", "kt", "rs"]
     },
     {
-        "expression": "exports_module_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "exports_module_directive",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "opens_module_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "opens_module_directive",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "provides_module_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "provides_module_directive",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "requires_module_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "requires_module_directive",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "uses_module_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "uses_module_directive",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "template_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "template_expression",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "compact_constructor_declaration",
-        "metrics": ["functions", "complexity"],
-        "type": "statement",
+        "type_name": "compact_constructor_declaration",
+        "category": "function",
+        "languages": ["java"]
+    },
+    {
+        "type_name": "condition",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "condition",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "guard",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "guard",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "multiline_string_fragment",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "multiline_string_fragment",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "permits",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "permits",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "record_pattern",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "record_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "record_pattern_body",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "record_pattern_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "record_pattern_component",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "record_pattern_component",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "string_interpolation",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "string_interpolation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "switch_block_statement_group",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "switch_block_statement_group",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "switch_rule",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "switch_rule",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["java"]
-    },
-    {
-        "expression": "type_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_list",
         "category": "",
         "languages": ["java", "php"]
     },
     {
-        "expression": "string_fragment",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "string_fragment",
         "category": "",
         "languages": ["java", "js", "ts", "tsx"]
     },
     {
-        "expression": "underscore_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "underscore_pattern",
         "category": "",
         "languages": ["java"]
     },
     {
-        "expression": "glimmer_template",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "glimmer_template",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "class_static_block",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "class_static_block",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "field_definition",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "field_definition",
         "category": "",
         "languages": ["js"]
     },
     {
-        "expression": "glimmer_closing_tag",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "glimmer_closing_tag",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "glimmer_opening_tag",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "glimmer_opening_tag",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "namespace_export",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "namespace_export",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "optional_chain",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "optional_chain",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "private_property_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "private_property_identifier",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "character_escape_seq",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "character_escape_seq",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "function_value_parameters",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "function_value_parameters",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "getter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "getter",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "import_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "import_list",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "multi_variable_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "multi_variable_declaration",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "not_nullable_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "not_nullable_type",
         "category": "",
         "languages": ["kt"]
     },
     {
-        "expression": "multiline_comment",
-        "metrics": ["comment_lines", "real_lines_of_code"],
-        "type": "statement",
+        "type_name": "multiline_comment",
         "category": "comment",
         "languages": ["kt"]
     },
     {
-        "expression": "match_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "match_expression",
         "category": "",
         "languages": ["php", "rs"]
     },
     {
-        "expression": "reference_assignment_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "reference_assignment_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "encapsed_string",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "encapsed_string",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "nowdoc",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "nowdoc",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "nullsafe_member_access_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "nullsafe_member_access_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "nullsafe_member_call_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "nullsafe_member_call_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "abstract_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "abstract_modifier",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "attribute_group",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "attribute_group",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "by_ref",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "by_ref",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "enum_case",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_case",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "enum_declaration_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_declaration_list",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "final_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "final_modifier",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "heredoc_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "heredoc_body",
         "category": "",
         "languages": ["php", "rb", "sh"]
     },
     {
-        "expression": "match_block",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "match_block",
         "category": "",
         "languages": ["php", "rs"]
     },
     {
-        "expression": "match_condition_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "match_condition_list",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "match_conditional_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "match_conditional_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "match_default_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "match_default_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "named_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "named_type",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "nowdoc_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "nowdoc_body",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "property_promotion_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "property_promotion_parameter",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "readonly_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "readonly_modifier",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "reference_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "reference_modifier",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "variadic_placeholder",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variadic_placeholder",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "bottom_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "bottom_type",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "heredoc_end",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "heredoc_end",
         "category": "",
         "languages": ["php", "rb", "sh"]
     },
     {
-        "expression": "heredoc_start",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "heredoc_start",
         "category": "",
         "languages": ["php", "sh"]
     },
     {
-        "expression": "nowdoc_string",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "nowdoc_string",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "string_value",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "string_value",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "template_literal_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "template_literal_type",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "this_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "this_type",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "instantiation_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "instantiation_expression",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "satisfies_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "satisfies_expression",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "asserts_annotation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "asserts_annotation",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "extends_type_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "extends_type_clause",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "override_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "override_modifier",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "match_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "match_statement",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "type_alias_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_alias_statement",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "as_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "as_pattern",
         "category": "",
         "languages": ["py", "rb"]
     },
     {
-        "expression": "keyword_separator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "keyword_separator",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "positional_separator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "positional_separator",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "case_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "case_clause",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "case_pattern",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "case_pattern",
         "category": "case_label",
         "languages": ["py"]
     },
     {
-        "expression": "class_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "class_pattern",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "complex_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "complex_pattern",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "constrained_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "constrained_type",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "dict_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dict_pattern",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "except_group_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "except_group_clause",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "keyword_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "keyword_pattern",
         "category": "",
         "languages": ["py", "rb"]
     },
     {
-        "expression": "member_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "member_type",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "splat_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "splat_pattern",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "splat_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "splat_type",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "string_content",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "string_content",
         "category": "",
         "languages": ["py", "cpp", "rb", "sh", "c", "json"]
     },
     {
-        "expression": "union_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "union_pattern",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "escape_interpolation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "escape_interpolation",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "line_continuation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "line_continuation",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "string_end",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "string_end",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "string_start",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "string_start",
         "category": "",
         "languages": ["py"]
     },
     {
-        "expression": "alignof_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "alignof_expression",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "fold_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "fold_expression",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "generic_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "generic_expression",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "gnu_asm_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "gnu_asm_expression",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "offsetof_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "offsetof_expression",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "requires_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "requires_clause",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "requires_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "requires_expression",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "placeholder_type_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "placeholder_type_specifier",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "alignas_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "alignas_specifier",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "binary_expression_bitand",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_bitand",
         "category": "binary_expression",
         "languages": ["cpp"],
+        "grammar_type_name": "binary_expression",
         "operator": "bitand"
     },
     {
-        "expression": "binary_expression_bitor",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_bitor",
         "category": "binary_expression",
         "languages": ["cpp"],
+        "grammar_type_name": "binary_expression",
         "operator": "bitor"
     },
     {
-        "expression": "binary_expression_not_eq",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_not_eq",
         "category": "binary_expression",
         "languages": ["cpp"],
+        "grammar_type_name": "binary_expression",
         "operator": "not_eq"
     },
     {
-        "expression": "compound_requirement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "compound_requirement",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "concept_definition",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "concept_definition",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "constraint_conjunction",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "constraint_conjunction",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "constraint_disjunction",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "constraint_disjunction",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "gnu_asm_clobber_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "gnu_asm_clobber_list",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "gnu_asm_goto_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "gnu_asm_goto_list",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "gnu_asm_input_operand",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "gnu_asm_input_operand",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "gnu_asm_input_operand_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "gnu_asm_input_operand_list",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "gnu_asm_output_operand",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "gnu_asm_output_operand",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "gnu_asm_output_operand_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "gnu_asm_output_operand_list",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "gnu_asm_qualifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "gnu_asm_qualifier",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "init_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "init_statement",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "nested_namespace_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "nested_namespace_specifier",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "pointer_type_declarator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "pointer_type_declarator",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "preproc_elifdef",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "preproc_elifdef",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "requirement_seq",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "requirement_seq",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "simple_requirement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "simple_requirement",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "subscript_argument_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "subscript_argument_list",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "type_requirement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_requirement",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "character",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "character",
         "category": "",
         "languages": ["cpp", "rb", "c"]
     },
     {
-        "expression": "raw_string_content",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "raw_string_content",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "raw_string_delimiter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "raw_string_delimiter",
         "category": "",
         "languages": ["cpp"]
     },
     {
-        "expression": "function_expression",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
+        "type_name": "function_expression",
+        "category": "function",
+        "languages": ["js", "ts", "tsx"]
+    },
+    {
+        "type_name": "import_attribute",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "import_attribute",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "html_character_reference",
         "category": "",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "html_character_reference",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["js", "ts", "tsx"]
-    },
-    {
-        "expression": "html_comment",
-        "metrics": ["comment_lines", "real_lines_of_code"],
-        "type": "statement",
+        "type_name": "html_comment",
         "category": "comment",
         "languages": ["js", "ts", "tsx"]
     },
     {
-        "expression": "const",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "const",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "adding_type_annotation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "adding_type_annotation",
         "category": "",
         "languages": ["ts", "tsx"]
     },
     {
-        "expression": "seh_leave_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "seh_leave_statement",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "seh_try_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "seh_try_statement",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "seh_except_clause",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "seh_except_clause",
+        "category": "catch_block",
+        "languages": ["cpp", "c"]
+    },
+    {
+        "type_name": "seh_finally_clause",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "seh_finally_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "subscript_range_designator",
         "category": "",
         "languages": ["cpp", "c"]
     },
     {
-        "expression": "subscript_range_designator",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["cpp", "c"]
-    },
-    {
-        "expression": "error_suppression_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "error_suppression_expression",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "disjunctive_normal_form_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "disjunctive_normal_form_type",
         "category": "",
         "languages": ["php"]
     },
     {
-        "expression": "_primary",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_primary",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "binary",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "conditional",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "conditional",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "operator_assignment",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "operator_assignment",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "range",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "range",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "unary",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unary",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "&.",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "&.",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": ".",
-        "metrics": [],
-        "type": "statement",
+        "type_name": ".",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "::",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "::",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "_arg",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_arg",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "break",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "break",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "match_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "match_pattern",
         "category": "",
         "languages": ["rb", "rs"]
     },
     {
-        "expression": "next",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "next",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "return",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "return",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "test_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "test_pattern",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "_variable",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_variable",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "element_reference",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "element_reference",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "scope_resolution",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "scope_resolution",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "_nonlocal_variable",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_nonlocal_variable",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "constant",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "constant",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "delimited_symbol",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "delimited_symbol",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "operator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "operator",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "simple_symbol",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "simple_symbol",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "class_variable",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "class_variable",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "global_variable",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "global_variable",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "instance_variable",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "instance_variable",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "_pattern_expr_basic",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_pattern_expr_basic",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "alternative_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "alternative_pattern",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "_pattern_constant",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_pattern_constant",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "_pattern_primitive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_pattern_primitive",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "expression_reference_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "expression_reference_pattern",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "find_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "find_pattern",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "hash_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "hash_pattern",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "variable_reference_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variable_reference_pattern",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "_simple_numeric",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_simple_numeric",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "encoding",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "encoding",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "file",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "file",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "heredoc_beginning",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "heredoc_beginning",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "line",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "line",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "self",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "self",
         "category": "",
         "languages": ["rb", "rs"]
     },
     {
-        "expression": "string_array",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "string_array",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "concatenation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "concatenation",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "word",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "word",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "ansi_c_string",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ansi_c_string",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "arithmetic_expansion",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "arithmetic_expansion",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "brace_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "brace_expression",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "command_substitution",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "command_substitution",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "expansion",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "expansion",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "process_substitution",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "process_substitution",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "raw_string",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "raw_string",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "simple_expansion",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "simple_expansion",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "translated_string",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "translated_string",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "c_style_for_statement",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "c_style_for_statement",
+        "category": "loop",
+        "languages": ["sh"]
+    },
+    {
+        "type_name": "command",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "command",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "declaration_command",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "declaration_command",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "negated_command",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "negated_command",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "pipeline",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "pipeline",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "redirected_statement",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "redirected_statement",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["sh"]
-    },
-    {
-        "expression": "subshell",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "subshell",
         "category": "",
         "languages": ["rb", "sh"]
     },
     {
-        "expression": "symbol_array",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "symbol_array",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "_pattern_expr",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_pattern_expr",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "_lhs",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_lhs",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "begin",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "begin",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "case",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "case",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "case_match",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "case_match",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "chained_string",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "chained_string",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "for",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "for",
+        "category": "loop",
         "languages": ["rb"]
     },
     {
-        "expression": "hash",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "hash",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "if",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "if",
+        "category": "if",
         "languages": ["rb"]
     },
     {
-        "expression": "method",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "method",
+        "category": "function",
         "languages": ["rb"]
     },
     {
-        "expression": "parenthesized_statements",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "parenthesized_statements",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "redo",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "redo",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "retry",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "retry",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "singleton_class",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "singleton_class",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "singleton_method",
-        "metrics": ["functions", "complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "singleton_method",
+        "category": "function",
         "languages": ["rb"]
     },
     {
-        "expression": "unless",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unless",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "until",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "until",
+        "category": "loop",
         "languages": ["rb"]
     },
     {
-        "expression": "while",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "while",
+        "category": "loop",
         "languages": ["rb"]
     },
     {
-        "expression": "complex",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "complex",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "rational",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "rational",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_expression",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "alias",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "alias",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "begin_block",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "begin_block",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "end_block",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "end_block",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "if_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "if_modifier",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "rescue_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "rescue_modifier",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "undef",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "undef",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "unless_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unless_modifier",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "until_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "until_modifier",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "while_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "while_modifier",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "bare_string",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "bare_string",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "bare_symbol",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "bare_symbol",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "block_argument",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "block_argument",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "block_body",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "block_body",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "block_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "block_parameter",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "block_parameters",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "block_parameters",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "body_statement",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "body_statement",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "destructured_left_assignment",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "destructured_left_assignment",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "destructured_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "destructured_parameter",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "do",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "do",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "do_block",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "do_block",
+        "category": "loop",
         "languages": ["rb"]
     },
     {
-        "expression": "else",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "else",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "elsif",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "elsif",
+        "category": "if",
         "languages": ["rb"]
     },
     {
-        "expression": "ensure",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ensure",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "exception_variable",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "exception_variable",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "exceptions",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "exceptions",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "forward_argument",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "forward_argument",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "forward_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "forward_parameter",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "hash_key_symbol",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "hash_key_symbol",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "hash_splat_argument",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "hash_splat_argument",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "hash_splat_nil",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "hash_splat_nil",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "hash_splat_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "hash_splat_parameter",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "if_guard",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "if_guard",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "in",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "in",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "in_clause",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "in_clause",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "keyword_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "keyword_parameter",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "left_assignment_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "left_assignment_list",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "method_parameters",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "method_parameters",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "rescue",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "rescue",
+        "category": "catch_block",
         "languages": ["rb"]
     },
     {
-        "expression": "rest_assignment",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "rest_assignment",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "right_assignment_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "right_assignment_list",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "splat_argument",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "splat_argument",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "splat_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "splat_parameter",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "then",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "then",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "unless_guard",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unless_guard",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "when",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "when",
         "category": "case_label",
         "languages": ["rb"]
     },
     {
-        "expression": "test_command",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "test_command",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "unset_command",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unset_command",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "variable_assignment",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variable_assignment",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "variable_assignments",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "variable_assignments",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "binary_expression_%=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_%=",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "%="
     },
     {
-        "expression": "binary_expression_&=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_&=",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "&="
     },
     {
-        "expression": "binary_expression_**=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_**=",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "**="
     },
     {
-        "expression": "binary_expression_*=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_*=",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "*="
     },
     {
-        "expression": "binary_expression_+=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_+=",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "+="
     },
     {
-        "expression": "binary_expression_-=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_-=",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "-="
     },
     {
-        "expression": "binary_expression_-a",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "binary_expression",
+        "type_name": "binary_expression_-a",
+        "category": "logical_binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "-a"
     },
     {
-        "expression": "binary_expression_-o",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "binary_expression",
+        "type_name": "binary_expression_-o",
+        "category": "logical_binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "-o"
     },
     {
-        "expression": "binary_expression_/=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_/=",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "/="
     },
     {
-        "expression": "binary_expression_<<=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_<<=",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "<<="
     },
     {
-        "expression": "binary_expression_=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_=",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "="
     },
     {
-        "expression": "binary_expression_=~",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_=~",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "=~"
     },
     {
-        "expression": "binary_expression_>>=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_>>=",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": ">>="
     },
     {
-        "expression": "binary_expression_^=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_^=",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "^="
     },
     {
-        "expression": "binary_expression_test_operator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_test_operator",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "test_operator"
     },
     {
-        "expression": "binary_expression_|=",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "binary_expression_|=",
         "category": "binary_expression",
         "languages": ["sh"],
+        "grammar_type_name": "binary_expression",
         "operator": "|="
     },
     {
-        "expression": "case_item",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "case_item",
+        "category": "case_label",
+        "languages": ["sh"]
+    },
+    {
+        "type_name": "command_name",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "command_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "do_group",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "do_group",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "file_redirect",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "file_redirect",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "heredoc_redirect",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "heredoc_redirect",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "herestring_redirect",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "herestring_redirect",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "extglob_pattern",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "extglob_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "file_descriptor",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "file_descriptor",
-        "metrics": [],
-        "type": "statement",
-        "category": "",
-        "languages": ["sh"]
-    },
-    {
-        "expression": "heredoc_content",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "heredoc_content",
         "category": "",
         "languages": ["rb", "sh"]
     },
     {
-        "expression": "uninterpreted",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "uninterpreted",
         "category": "",
         "languages": ["rb"]
     },
     {
-        "expression": "associated_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "associated_type",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "attribute_item",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "attribute_item",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "const_item",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "const_item",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "enum_item",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_item",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "extern_crate_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "extern_crate_declaration",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "foreign_mod_item",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "foreign_mod_item",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "function_item",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "function_item",
+        "category": "function",
         "languages": ["rs"]
     },
     {
-        "expression": "function_signature_item",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "function_signature_item",
+        "category": "function",
         "languages": ["rs"]
     },
     {
-        "expression": "impl_item",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "impl_item",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "inner_attribute_item",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "inner_attribute_item",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "let_declaration",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "let_declaration",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "macro_definition",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "macro_definition",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "macro_invocation",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "macro_invocation",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "mod_item",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "mod_item",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "static_item",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "static_item",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "struct_item",
-        "metrics": ["classes"],
-        "type": "statement",
-        "category": "",
+        "type_name": "struct_item",
+        "category": "struct_definition",
         "languages": ["rs"]
     },
     {
-        "expression": "trait_item",
-        "metrics": ["classes"],
-        "type": "statement",
-        "category": "",
+        "type_name": "trait_item",
+        "category": "trait_definition",
         "languages": ["rs"]
     },
     {
-        "expression": "type_item",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_item",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "union_item",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "union_item",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "array_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "array_expression",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "async_block",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "async_block",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "break_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "break_expression",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "closure_expression",
-        "metrics": ["complexity", "functions"],
-        "type": "statement",
-        "category": "",
+        "type_name": "closure_expression",
+        "category": "function",
         "languages": ["rs"]
     },
     {
-        "expression": "compound_assignment_expr",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "compound_assignment_expr",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "const_block",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "const_block",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "continue_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "continue_expression",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "for_expression",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "for_expression",
+        "category": "loop",
         "languages": ["rs"]
     },
     {
-        "expression": "generic_function",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "generic_function",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "loop_expression",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "loop_expression",
+        "category": "loop",
         "languages": ["rs"]
     },
     {
-        "expression": "metavariable",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "metavariable",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "reference_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "reference_expression",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "return_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "return_expression",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "struct_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "struct_expression",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "type_cast_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_cast_expression",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "unit_expression",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unit_expression",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "unsafe_block",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unsafe_block",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "while_expression",
-        "metrics": ["complexity"],
-        "type": "statement",
-        "category": "",
+        "type_name": "while_expression",
+        "category": "loop",
         "languages": ["rs"]
     },
     {
-        "expression": "negative_literal",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "negative_literal",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "_",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "_literal_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "_literal_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "captured_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "captured_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "mut_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "mut_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "range_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "range_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "ref_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ref_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "reference_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "reference_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "remaining_field_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "remaining_field_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "struct_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "struct_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "tuple_struct_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "tuple_struct_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "abstract_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "abstract_type",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "bounded_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "bounded_type",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "dynamic_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "dynamic_type",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "empty_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "empty_type",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "reference_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "reference_type",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "unit_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "unit_type",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "base_field_initializer",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "base_field_initializer",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "bracketed_type",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "bracketed_type",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "closure_parameters",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "closure_parameters",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "const_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "const_parameter",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "constrained_type_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "constrained_type_parameter",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "enum_variant",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_variant",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "enum_variant_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "enum_variant_list",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "extern_modifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "extern_modifier",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "field_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "field_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "for_lifetimes",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "for_lifetimes",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "fragment_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "fragment_specifier",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "function_modifiers",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "function_modifiers",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "generic_type_with_turbofish",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "generic_type_with_turbofish",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "higher_ranked_trait_bound",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "higher_ranked_trait_bound",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "let_chain",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "let_chain",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "let_condition",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "let_condition",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "lifetime",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "lifetime",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "loop_label",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "loop_label",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "macro_rule",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "macro_rule",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "match_arm",
-        "metrics": ["complexity"],
-        "type": "statement",
+        "type_name": "match_arm",
         "category": "case_label",
         "languages": ["rs"]
     },
     {
-        "expression": "optional_type_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "optional_type_parameter",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "ordered_field_declaration_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "ordered_field_declaration_list",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "removed_trait_bound",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "removed_trait_bound",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "scoped_use_list",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "scoped_use_list",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "self_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "self_parameter",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "shorthand_field_initializer",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "shorthand_field_initializer",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "token_binding_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "token_binding_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "token_repetition",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "token_repetition",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "token_repetition_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "token_repetition_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "token_tree",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "token_tree",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "token_tree_pattern",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "token_tree_pattern",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "trait_bounds",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "trait_bounds",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "type_binding",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "type_binding",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "use_wildcard",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "use_wildcard",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "where_predicate",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "where_predicate",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "crate",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "crate",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "mutable_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "mutable_specifier",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "shebang",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "shebang",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "shorthand_field_identifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "shorthand_field_identifier",
         "category": "",
         "languages": ["rs"]
     },
     {
-        "expression": "special_variable_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "special_variable_name",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "test_operator",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "test_operator",
         "category": "",
         "languages": ["sh"]
     },
     {
-        "expression": "macro_type_specifier",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "macro_type_specifier",
         "category": "",
         "languages": ["c"]
     },
     {
-        "expression": "document",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "document",
         "category": "",
         "languages": ["json", "yaml"]
     },
     {
-        "expression": "alias",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "alias",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "anchor",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "anchor",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "block_mapping",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "block_mapping",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "block_mapping_pair",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "block_mapping_pair",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "block_node",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "block_node",
         "category": "nesting",
         "languages": ["yaml"]
     },
     {
-        "expression": "block_scalar",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "block_scalar",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "block_sequence",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "block_sequence",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "block_sequence_item",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "block_sequence_item",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "double_quote_scalar",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "double_quote_scalar",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "flow_mapping",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "flow_mapping",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "flow_node",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "flow_node",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "flow_pair",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "flow_pair",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "flow_sequence",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "flow_sequence",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "plain_scalar",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "plain_scalar",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "reserved_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "reserved_directive",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "single_quote_scalar",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "single_quote_scalar",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "stream",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "stream",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "tag_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "tag_directive",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "yaml_directive",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "yaml_directive",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "alias_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "alias_name",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "anchor_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "anchor_name",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "boolean_scalar",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "boolean_scalar",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "directive_name",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "directive_name",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "directive_parameter",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "directive_parameter",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "float_scalar",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "float_scalar",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "integer_scalar",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "integer_scalar",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "null_scalar",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "null_scalar",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "string_scalar",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "string_scalar",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "tag",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "tag",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "tag_handle",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "tag_handle",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "tag_prefix",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "tag_prefix",
         "category": "",
         "languages": ["yaml"]
     },
     {
-        "expression": "yaml_version",
-        "metrics": [],
-        "type": "statement",
+        "type_name": "yaml_version",
         "category": "",
         "languages": ["yaml"]
     }

--- a/src/parser/config/nodeTypesConfig.json
+++ b/src/parser/config/nodeTypesConfig.json
@@ -2423,7 +2423,7 @@
     },
     {
         "type_name": "conjunction_expression",
-        "category": "conditional",
+        "category": "logical_binary_expression",
         "languages": ["kt"]
     },
     {
@@ -2453,7 +2453,7 @@
     },
     {
         "type_name": "disjunction_expression",
-        "category": "conditional",
+        "category": "logical_binary_expression",
         "languages": ["kt"]
     },
     {

--- a/src/parser/helper/Helper.test.ts
+++ b/src/parser/helper/Helper.test.ts
@@ -1,6 +1,14 @@
 import { getTestConfiguration } from "../../../test/metric-end-results/TestHelper";
-import { formatPrintPath } from "./Helper";
+import {
+    formatPrintPath,
+    getNodeTypeNamesByCategory,
+    getNodeTypesByCategory,
+    getQueryStatementsByCategories,
+    getQueryStatementsByCategory,
+} from "./Helper";
 import path from "path";
+import { NodeTypeCategory, NodeTypeConfig } from "./Model";
+import { NodeTypeQueryStatement } from "../queries/QueryStatements";
 
 describe("Helper.ts", () => {
     describe("formatPrintPath(...)", () => {
@@ -88,6 +96,147 @@ describe("Helper.ts", () => {
             expect(formatPrintPath(filePath, config, path.win32)).toEqual(
                 "more-code\\file.extension",
             );
+        });
+    });
+
+    describe("Helper for node types", () => {
+        const exampleNodeTypes: NodeTypeConfig[] = [
+            {
+                type_name: "node type 1",
+                languages: ["cpp"],
+                category: NodeTypeCategory.Other,
+            },
+            {
+                type_name: "node type 2",
+                languages: ["cpp", "js", "ts", "tsx"],
+                activated_for_languages: ["cpp"],
+                category: NodeTypeCategory.Comment,
+            },
+            {
+                type_name: "node type 3",
+                languages: ["cpp"],
+                category: NodeTypeCategory.Other,
+            },
+            {
+                type_name: "node type 4",
+                languages: ["java"],
+                category: NodeTypeCategory.Comment,
+            },
+            {
+                type_name: "node type 5",
+                languages: ["go"],
+                category: NodeTypeCategory.Comment,
+            },
+            {
+                type_name: "node type 6",
+                languages: ["java"],
+                category: NodeTypeCategory.ClassDefinition,
+            },
+        ];
+
+        describe("getNodeTypesByCategory(...)", () => {
+            it("should return all node types of a category", () => {
+                const result = getNodeTypesByCategory(exampleNodeTypes, NodeTypeCategory.Comment);
+
+                const expectedResult = [
+                    {
+                        type_name: "node type 2",
+                        languages: ["cpp", "js", "ts", "tsx"],
+                        activated_for_languages: ["cpp"],
+                        category: NodeTypeCategory.Comment,
+                    },
+                    {
+                        type_name: "node type 4",
+                        languages: ["java"],
+                        category: NodeTypeCategory.Comment,
+                    },
+                    {
+                        type_name: "node type 5",
+                        languages: ["go"],
+                        category: NodeTypeCategory.Comment,
+                    },
+                ];
+
+                expect(result).toEqual(expectedResult);
+            });
+        });
+
+        describe("getNodeTypeNamesByCategory(...)", () => {
+            it("should return the names of all node types of a category", () => {
+                const result = getNodeTypeNamesByCategory(
+                    exampleNodeTypes,
+                    NodeTypeCategory.Comment,
+                );
+
+                const expectedResult = ["node type 2", "node type 4", "node type 5"];
+
+                expect(result).toEqual(expectedResult);
+            });
+        });
+
+        describe("getQueryStatementsByCategory(...)", () => {
+            it("should return query statements fo all node types of a category", () => {
+                const result = getQueryStatementsByCategory(
+                    exampleNodeTypes,
+                    NodeTypeCategory.Comment,
+                );
+
+                const expectedResult = [
+                    new NodeTypeQueryStatement({
+                        type_name: "node type 2",
+                        languages: ["cpp", "js", "ts", "tsx"],
+                        activated_for_languages: ["cpp"],
+                        category: NodeTypeCategory.Comment,
+                    }),
+                    new NodeTypeQueryStatement({
+                        type_name: "node type 4",
+                        languages: ["java"],
+                        category: NodeTypeCategory.Comment,
+                    }),
+                    new NodeTypeQueryStatement({
+                        type_name: "node type 5",
+                        languages: ["go"],
+                        category: NodeTypeCategory.Comment,
+                    }),
+                ];
+
+                expect(result).toEqual(expectedResult);
+            });
+        });
+
+        describe("getQueryStatementsByCategories(...)", () => {
+            it("should return query statements fo all node types that match one of the categories", () => {
+                const result = getQueryStatementsByCategories(
+                    exampleNodeTypes,
+                    new Set([NodeTypeCategory.Comment, NodeTypeCategory.ClassDefinition]),
+                );
+
+                const expectedResult = [
+                    new NodeTypeQueryStatement({
+                        type_name: "node type 2",
+                        languages: ["cpp", "js", "ts", "tsx"],
+                        activated_for_languages: ["cpp"],
+                        category: NodeTypeCategory.Comment,
+                    }),
+                    new NodeTypeQueryStatement({
+                        type_name: "node type 4",
+                        languages: ["java"],
+                        category: NodeTypeCategory.Comment,
+                    }),
+                    new NodeTypeQueryStatement({
+                        type_name: "node type 5",
+                        languages: ["go"],
+                        category: NodeTypeCategory.Comment,
+                    }),
+                    new NodeTypeQueryStatement({
+                        type_name: "node type 6",
+                        languages: ["java"],
+                        category: NodeTypeCategory.ClassDefinition,
+                    }),
+                ];
+
+                expect(result).toEqual(expectedResult);
+            });
         });
     });
 });

--- a/src/parser/helper/Helper.test.ts
+++ b/src/parser/helper/Helper.test.ts
@@ -1,10 +1,9 @@
 import { getTestConfiguration } from "../../../test/metric-end-results/TestHelper";
 import {
     formatPrintPath,
-    getNodeTypeNamesByCategory,
-    getNodeTypesByCategory,
+    getNodeTypeNamesByCategories,
+    getNodeTypesByCategories,
     getQueryStatementsByCategories,
-    getQueryStatementsByCategory,
 } from "./Helper";
 import path from "path";
 import { NodeTypeCategory, NodeTypeConfig } from "./Model";
@@ -102,6 +101,11 @@ describe("Helper.ts", () => {
     describe("Helper for node types", () => {
         const exampleNodeTypes: NodeTypeConfig[] = [
             {
+                type_name: "node type 0",
+                languages: ["rs"],
+                category: NodeTypeCategory.If,
+            },
+            {
                 type_name: "node type 1",
                 languages: ["cpp"],
                 category: NodeTypeCategory.Other,
@@ -136,26 +140,38 @@ describe("Helper.ts", () => {
 
         describe("getNodeTypesByCategory(...)", () => {
             it("should return all node types of a category", () => {
-                const result = getNodeTypesByCategory(exampleNodeTypes, NodeTypeCategory.Comment);
+                const result = getNodeTypesByCategories(exampleNodeTypes, NodeTypeCategory.Comment);
 
                 const expectedResult = [
-                    {
-                        type_name: "node type 2",
-                        languages: ["cpp", "js", "ts", "tsx"],
-                        activated_for_languages: ["cpp"],
-                        category: NodeTypeCategory.Comment,
-                    },
-                    {
-                        type_name: "node type 4",
-                        languages: ["java"],
-                        category: NodeTypeCategory.Comment,
-                    },
-                    {
-                        type_name: "node type 5",
-                        languages: ["go"],
-                        category: NodeTypeCategory.Comment,
-                    },
+                    exampleNodeTypes[2],
+                    exampleNodeTypes[4],
+                    exampleNodeTypes[5],
                 ];
+
+                expect(result).toEqual(expectedResult);
+            });
+
+            it("should return all node types that match one of multiple categories", () => {
+                const result = getNodeTypesByCategories(
+                    exampleNodeTypes,
+                    NodeTypeCategory.Comment,
+                    NodeTypeCategory.ClassDefinition,
+                );
+
+                const expectedResult = [
+                    exampleNodeTypes[2],
+                    exampleNodeTypes[4],
+                    exampleNodeTypes[5],
+                    exampleNodeTypes[6],
+                ];
+
+                expect(result).toEqual(expectedResult);
+            });
+
+            it("should return an empty list when no category is passed", () => {
+                const result = getNodeTypesByCategories(exampleNodeTypes);
+
+                const expectedResult: string[] = [];
 
                 expect(result).toEqual(expectedResult);
             });
@@ -163,7 +179,7 @@ describe("Helper.ts", () => {
 
         describe("getNodeTypeNamesByCategory(...)", () => {
             it("should return the names of all node types of a category", () => {
-                const result = getNodeTypeNamesByCategory(
+                const result = getNodeTypeNamesByCategories(
                     exampleNodeTypes,
                     NodeTypeCategory.Comment,
                 );
@@ -172,11 +188,38 @@ describe("Helper.ts", () => {
 
                 expect(result).toEqual(expectedResult);
             });
+
+            it("should return the names of all node types that match one of multiple categories", () => {
+                const result = getNodeTypeNamesByCategories(
+                    exampleNodeTypes,
+                    NodeTypeCategory.Comment,
+                    NodeTypeCategory.ClassDefinition,
+                    NodeTypeCategory.If,
+                );
+
+                const expectedResult = [
+                    "node type 0",
+                    "node type 2",
+                    "node type 4",
+                    "node type 5",
+                    "node type 6",
+                ];
+
+                expect(result).toEqual(expectedResult);
+            });
+
+            it("should return an empty list when no category is passed", () => {
+                const result = getNodeTypeNamesByCategories(exampleNodeTypes);
+
+                const expectedResult: string[] = [];
+
+                expect(result).toEqual(expectedResult);
+            });
         });
 
         describe("getQueryStatementsByCategory(...)", () => {
-            it("should return query statements fo all node types of a category", () => {
-                const result = getQueryStatementsByCategory(
+            it("should return query statements for all node types of a single category", () => {
+                const result = getQueryStatementsByCategories(
                     exampleNodeTypes,
                     NodeTypeCategory.Comment,
                 );
@@ -202,13 +245,12 @@ describe("Helper.ts", () => {
 
                 expect(result).toEqual(expectedResult);
             });
-        });
 
-        describe("getQueryStatementsByCategories(...)", () => {
-            it("should return query statements fo all node types that match one of the categories", () => {
+            it("should return query statements for all node types that match one of multiple categories", () => {
                 const result = getQueryStatementsByCategories(
                     exampleNodeTypes,
-                    new Set([NodeTypeCategory.Comment, NodeTypeCategory.ClassDefinition]),
+                    NodeTypeCategory.Comment,
+                    NodeTypeCategory.ClassDefinition,
                 );
 
                 const expectedResult = [
@@ -234,6 +276,14 @@ describe("Helper.ts", () => {
                         category: NodeTypeCategory.ClassDefinition,
                     }),
                 ];
+
+                expect(result).toEqual(expectedResult);
+            });
+
+            it("should return an empty list when no category is passed", () => {
+                const result = getQueryStatementsByCategories(exampleNodeTypes);
+
+                const expectedResult: NodeTypeQueryStatement[] = [];
 
                 expect(result).toEqual(expectedResult);
             });

--- a/src/parser/helper/Helper.ts
+++ b/src/parser/helper/Helper.ts
@@ -167,18 +167,6 @@ async function* findFilesAsyncRecursive(
     } // End of for await (directory entries)
 }
 
-export function findNodeTypesByCategory(
-    allNodeTypes: NodeTypeConfig[],
-    category: NodeTypeCategory,
-    callback: (nodeTypeConfig: NodeTypeConfig) => void,
-) {
-    for (const nodeTypeConfig of allNodeTypes) {
-        if (nodeTypeConfig.category === category) {
-            callback(nodeTypeConfig);
-        }
-    }
-}
-
 export function findNodeTypesByCategories(
     allNodeTypes: NodeTypeConfig[],
     categories: Set<NodeTypeCategory>,
@@ -191,25 +179,12 @@ export function findNodeTypesByCategories(
     }
 }
 
-export function getQueryStatementsByCategory(
-    allNodeTypes: NodeTypeConfig[],
-    category: NodeTypeCategory,
-) {
-    const statements: NodeTypeQueryStatement[] = [];
-    findNodeTypesByCategory(allNodeTypes, category, (nodeType) => {
-        const queryStatement = new NodeTypeQueryStatement(nodeType);
-        statements.push(queryStatement);
-    });
-
-    return statements;
-}
-
 export function getQueryStatementsByCategories(
     allNodeTypes: NodeTypeConfig[],
-    categories: Set<NodeTypeCategory>,
+    ...categories: NodeTypeCategory[]
 ) {
     const statements: NodeTypeQueryStatement[] = [];
-    findNodeTypesByCategories(allNodeTypes, categories, (nodeType) => {
+    findNodeTypesByCategories(allNodeTypes, new Set(categories), (nodeType) => {
         const queryStatement = new NodeTypeQueryStatement(nodeType);
         statements.push(queryStatement);
     });
@@ -217,20 +192,24 @@ export function getQueryStatementsByCategories(
     return statements;
 }
 
-export function getNodeTypesByCategory(allNodeTypes: NodeTypeConfig[], category: NodeTypeCategory) {
+export function getNodeTypesByCategories(
+    allNodeTypes: NodeTypeConfig[],
+    ...categories: NodeTypeCategory[]
+) {
     const types: NodeTypeConfig[] = [];
-    findNodeTypesByCategory(allNodeTypes, category, (nodeTypeConfig) => types.push(nodeTypeConfig));
+    findNodeTypesByCategories(allNodeTypes, new Set(categories), (nodeTypeConfig) =>
+        types.push(nodeTypeConfig),
+    );
     return types;
 }
 
-export function getNodeTypeNamesByCategory(
+export function getNodeTypeNamesByCategories(
     allNodeTypes: NodeTypeConfig[],
-    category: NodeTypeCategory,
+    ...categories: NodeTypeCategory[]
 ) {
     const typeNames: string[] = [];
-    findNodeTypesByCategory(allNodeTypes, category, (nodeTypeConfig) => {
-        const { type_name } = nodeTypeConfig;
-        typeNames.push(type_name);
+    findNodeTypesByCategories(allNodeTypes, new Set(categories), (nodeTypeConfig) => {
+        typeNames.push(nodeTypeConfig.type_name);
     });
     return typeNames;
 }

--- a/src/parser/helper/Model.ts
+++ b/src/parser/helper/Model.ts
@@ -1,10 +1,32 @@
-export interface ExpressionMetricMapping {
-    expression: string;
-    metrics: string[];
-    type: "statement" | "keyword";
+/**
+ * Configuration for a single syntax node type.
+ * May maps a syntax node type to a category if it should be used to calculate a metric.
+ */
+export interface NodeTypeConfig {
+    /**
+     * Name of the node type. Usually equivalent to the name used in the tree-sitter grammar.
+     */
+    type_name: string;
+    /**
+     * Can be used to consider the node type only for a certain subset of the languages that have the node type.
+     */
     activated_for_languages?: string[];
+    /**
+     * Languages that have the node type.
+     */
     languages: string[];
+    /**
+     * Category of the node type.
+     * This is used to put node types of different languages in a unified semantic category.
+     */
     category: NodeTypeCategory;
+    /**
+     * Name of the node type in the tree-sitter grammar, if it is different to the type_name.
+     */
+    grammar_type_name?: string;
+    /**
+     * Operator of this node type, if any.
+     */
     operator?: string;
 }
 
@@ -14,9 +36,29 @@ export enum NodeTypeCategory {
      */
     Other = "",
     /**
-     * Node types that represent a binary expression.
+     * Node types that represent a logical binary expression, like "and" and "or".
      */
-    BinaryExpression = "binary_expression",
+    LogicalBinaryExpression = "logical_binary_expression",
+    /**
+     * Node types that represent a binary expression that is no logical binary expression,
+     * like addition or subtraction.
+     */
+    OtherBinaryExpression = "binary_expression",
+    /**
+     * Node type that represents a comment.
+     */
+    Comment = "comment",
+    /**
+     * Represents a function definition.
+     */
+    Function = "function",
+    /**
+     * Node types that define the nesting level in structured text.
+     */
+    Nesting = "nesting",
+
+    // Language constructs that affect the control flow:
+
     /**
      * Node types that are used for case labels in a switch-case-block.
      * May also be used for default labels by some language grammar(s).
@@ -27,7 +69,50 @@ export enum NodeTypeCategory {
      */
     DefaultLabel = "default_label",
     /**
-     * Node types that define the nesting level in structured text.
+     * Represents if-statements, also including dedicated else-if-statements.
      */
-    Nesting = "nesting",
+    If = "if",
+    /**
+     * Represents loops.
+     */
+    Loop = "loop",
+    /**
+     * Represents catch blocks.
+     */
+    CatchBlock = "catch_block",
+    /**
+     * Represents other conditional expressions, like ternary operators.
+     */
+    Conditional = "conditional",
+
+    // Classes, structs and similar constructs:
+
+    /**
+     * Represents a class definition.
+     */
+    ClassDefinition = "class_definition",
+    /**
+     * Represents an enum definition.
+     */
+    EnumDefinition = "enum_definition",
+    /**
+     * Represents a struct definition.
+     */
+    StructDefinition = "struct_definition",
+    /**
+     * Represents a record definition.
+     */
+    RecordDefinition = "record_definition",
+    /**
+     * Represents a union definition. For unions like in C and C++.
+     */
+    UnionDefinition = "c_union_definition",
+    /**
+     * Represents a trait definition.
+     */
+    TraitDefinition = "trait_definition",
+    /**
+     * Represents a interface definition.
+     */
+    InterfaceDefinition = "interface_definition",
 }

--- a/src/parser/helper/Model.ts
+++ b/src/parser/helper/Model.ts
@@ -83,7 +83,7 @@ export enum NodeTypeCategory {
     /**
      * Represents other conditional expressions, like ternary operators.
      */
-    Conditional = "conditional",
+    ConditionalExpression = "conditional_expression",
 
     // Classes, structs and similar constructs:
 

--- a/src/parser/metrics/Classes.ts
+++ b/src/parser/metrics/Classes.ts
@@ -29,7 +29,7 @@ export class Classes implements Metric {
     constructor(allNodeTypes: NodeTypeConfig[]) {
         this.statementsSuperSet = getQueryStatementsByCategories(
             allNodeTypes,
-            this.nodeTypeCategories,
+            ...this.nodeTypeCategories,
         );
         this.addQueriesForTSAndTSX();
         this.addQueriesForCAndCpp();

--- a/src/parser/metrics/Classes.ts
+++ b/src/parser/metrics/Classes.ts
@@ -1,5 +1,5 @@
 import { QueryBuilder } from "../queries/QueryBuilder";
-import { ExpressionMetricMapping } from "../helper/Model";
+import { NodeTypeCategory, NodeTypeConfig } from "../helper/Model";
 import { FileMetric, Metric, MetricResult, ParsedFile } from "./Metric";
 import { debuglog, DebugLoggerFunction } from "node:util";
 import { QueryMatch } from "tree-sitter";
@@ -7,7 +7,7 @@ import {
     QueryStatementInterface,
     SimpleLanguageSpecificQueryStatement,
 } from "../queries/QueryStatements";
-import { getQueryStatements } from "../helper/Helper";
+import { getQueryStatementsByCategories } from "../helper/Helper";
 
 let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
     dlog = logger;
@@ -16,8 +16,21 @@ let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
 export class Classes implements Metric {
     private readonly statementsSuperSet: QueryStatementInterface[] = [];
 
-    constructor(allNodeTypes: ExpressionMetricMapping[]) {
-        this.statementsSuperSet = getQueryStatements(allNodeTypes, this.getName());
+    private nodeTypeCategories = new Set([
+        NodeTypeCategory.ClassDefinition,
+        NodeTypeCategory.EnumDefinition,
+        NodeTypeCategory.StructDefinition,
+        NodeTypeCategory.RecordDefinition,
+        NodeTypeCategory.UnionDefinition,
+        NodeTypeCategory.TraitDefinition,
+        NodeTypeCategory.InterfaceDefinition,
+    ]);
+
+    constructor(allNodeTypes: NodeTypeConfig[]) {
+        this.statementsSuperSet = getQueryStatementsByCategories(
+            allNodeTypes,
+            this.nodeTypeCategories,
+        );
         this.addQueriesForTSAndTSX();
         this.addQueriesForCAndCpp();
     }
@@ -51,7 +64,7 @@ export class Classes implements Metric {
     body: (enumerator_list)
 ]) @enum_with_body_or_type
 
-(enum_specifier "enum" 
+(enum_specifier "enum"
     [
         "class"
         "struct"

--- a/src/parser/metrics/CommentLines.ts
+++ b/src/parser/metrics/CommentLines.ts
@@ -1,6 +1,6 @@
 import { QueryBuilder } from "../queries/QueryBuilder";
-import { ExpressionMetricMapping } from "../helper/Model";
-import { getQueryStatements } from "../helper/Helper";
+import { NodeTypeCategory, NodeTypeConfig } from "../helper/Model";
+import { getQueryStatementsByCategory } from "../helper/Helper";
 import { FileMetric, Metric, MetricResult, ParsedFile } from "./Metric";
 import { QueryMatch, SyntaxNode } from "tree-sitter";
 import { debuglog, DebugLoggerFunction } from "node:util";
@@ -22,8 +22,11 @@ export class CommentLines implements Metric {
      * Constructor of the class {@link CommentLines}.
      * @param allNodeTypes List of all configured syntax node types.
      */
-    constructor(allNodeTypes: ExpressionMetricMapping[]) {
-        this.statementsSuperSet = getQueryStatements(allNodeTypes, this.getName());
+    constructor(allNodeTypes: NodeTypeConfig[]) {
+        this.statementsSuperSet = getQueryStatementsByCategory(
+            allNodeTypes,
+            NodeTypeCategory.Comment,
+        );
     }
 
     async calculate(parsedFile: ParsedFile): Promise<MetricResult> {

--- a/src/parser/metrics/CommentLines.ts
+++ b/src/parser/metrics/CommentLines.ts
@@ -1,6 +1,6 @@
 import { QueryBuilder } from "../queries/QueryBuilder";
 import { NodeTypeCategory, NodeTypeConfig } from "../helper/Model";
-import { getQueryStatementsByCategory } from "../helper/Helper";
+import { getQueryStatementsByCategories } from "../helper/Helper";
 import { FileMetric, Metric, MetricResult, ParsedFile } from "./Metric";
 import { QueryMatch, SyntaxNode } from "tree-sitter";
 import { debuglog, DebugLoggerFunction } from "node:util";
@@ -23,7 +23,7 @@ export class CommentLines implements Metric {
      * @param allNodeTypes List of all configured syntax node types.
      */
     constructor(allNodeTypes: NodeTypeConfig[]) {
-        this.statementsSuperSet = getQueryStatementsByCategory(
+        this.statementsSuperSet = getQueryStatementsByCategories(
             allNodeTypes,
             NodeTypeCategory.Comment,
         );

--- a/src/parser/metrics/Complexity.ts
+++ b/src/parser/metrics/Complexity.ts
@@ -26,6 +26,7 @@ export class Complexity implements Metric {
         NodeTypeCategory.LogicalBinaryExpression,
         NodeTypeCategory.CaseLabel,
         NodeTypeCategory.CatchBlock,
+        NodeTypeCategory.Function,
     ]);
 
     constructor(allNodeTypes: NodeTypeConfig[]) {
@@ -48,7 +49,7 @@ export class Complexity implements Metric {
                     caseNodeTypes.push(nodeType);
                 } else if (nodeType.category === NodeTypeCategory.LogicalBinaryExpression) {
                     this.addBinaryExpressionQueryStatement(nodeType);
-                } else if (nodeType.category === NodeTypeCategory.Other) {
+                } else {
                     this.addExpressionQueryStatement(nodeType);
                 }
             }

--- a/src/parser/metrics/Complexity.ts
+++ b/src/parser/metrics/Complexity.ts
@@ -47,7 +47,10 @@ export class Complexity implements Metric {
             if (this.nodeTypeCategories.has(nodeType.category)) {
                 if (nodeType.category === NodeTypeCategory.CaseLabel) {
                     caseNodeTypes.push(nodeType);
-                } else if (nodeType.category === NodeTypeCategory.LogicalBinaryExpression) {
+                } else if (
+                    nodeType.category === NodeTypeCategory.LogicalBinaryExpression &&
+                    nodeType.operator !== undefined
+                ) {
                     this.addBinaryExpressionQueryStatement(nodeType);
                 } else {
                     this.addExpressionQueryStatement(nodeType);

--- a/src/parser/metrics/Complexity.ts
+++ b/src/parser/metrics/Complexity.ts
@@ -22,7 +22,7 @@ export class Complexity implements Metric {
     private nodeTypeCategories = new Set([
         NodeTypeCategory.If,
         NodeTypeCategory.Loop,
-        NodeTypeCategory.Conditional,
+        NodeTypeCategory.ConditionalExpression,
         NodeTypeCategory.LogicalBinaryExpression,
         NodeTypeCategory.CaseLabel,
         NodeTypeCategory.CatchBlock,

--- a/src/parser/metrics/Functions.ts
+++ b/src/parser/metrics/Functions.ts
@@ -1,6 +1,6 @@
 import { QueryBuilder } from "../queries/QueryBuilder";
-import { ExpressionMetricMapping } from "../helper/Model";
-import { getQueryStatements } from "../helper/Helper";
+import { NodeTypeCategory, NodeTypeConfig } from "../helper/Model";
+import { getQueryStatementsByCategory } from "../helper/Helper";
 import { FileMetric, Metric, MetricResult, ParsedFile } from "./Metric";
 import { debuglog, DebugLoggerFunction } from "node:util";
 import { QueryMatch } from "tree-sitter";
@@ -14,8 +14,11 @@ let dlog: DebugLoggerFunction = debuglog("metric-gardener", (logger) => {
 export class Functions implements Metric {
     private readonly statementsSuperSet: QueryStatementInterface[] = [];
 
-    constructor(allNodeTypes: ExpressionMetricMapping[]) {
-        this.statementsSuperSet = getQueryStatements(allNodeTypes, this.getName());
+    constructor(allNodeTypes: NodeTypeConfig[]) {
+        this.statementsSuperSet = getQueryStatementsByCategory(
+            allNodeTypes,
+            NodeTypeCategory.Function,
+        );
     }
 
     async calculate(parsedFile: ParsedFile): Promise<MetricResult> {

--- a/src/parser/metrics/Functions.ts
+++ b/src/parser/metrics/Functions.ts
@@ -1,6 +1,6 @@
 import { QueryBuilder } from "../queries/QueryBuilder";
 import { NodeTypeCategory, NodeTypeConfig } from "../helper/Model";
-import { getQueryStatementsByCategory } from "../helper/Helper";
+import { getQueryStatementsByCategories } from "../helper/Helper";
 import { FileMetric, Metric, MetricResult, ParsedFile } from "./Metric";
 import { debuglog, DebugLoggerFunction } from "node:util";
 import { QueryMatch } from "tree-sitter";
@@ -15,7 +15,7 @@ export class Functions implements Metric {
     private readonly statementsSuperSet: QueryStatementInterface[] = [];
 
     constructor(allNodeTypes: NodeTypeConfig[]) {
-        this.statementsSuperSet = getQueryStatementsByCategory(
+        this.statementsSuperSet = getQueryStatementsByCategories(
             allNodeTypes,
             NodeTypeCategory.Function,
         );

--- a/src/parser/metrics/MaxNestingLevel.test.ts
+++ b/src/parser/metrics/MaxNestingLevel.test.ts
@@ -2,31 +2,25 @@ import { MaxNestingLevel } from "./MaxNestingLevel";
 import Parser from "tree-sitter";
 import { Language, languageToGrammar } from "../helper/Language";
 import { FileMetric, ParsedFile } from "./Metric";
-import { ExpressionMetricMapping, NodeTypeCategory } from "../helper/Model";
+import { NodeTypeConfig, NodeTypeCategory } from "../helper/Model";
 
 describe("MaxNestingLevel.calculate(...)", () => {
     let maxNestingLevel: MaxNestingLevel;
     let parser: Parser;
     let tree: Parser.Tree;
-    const nodeTypes: ExpressionMetricMapping[] = [
+    const nodeTypes: NodeTypeConfig[] = [
         {
-            expression: "array",
-            metrics: [],
-            type: "statement",
+            type_name: "array",
             category: NodeTypeCategory.Nesting,
             languages: ["json"],
         },
         {
-            expression: "object",
-            metrics: [],
-            type: "statement",
+            type_name: "object",
             category: NodeTypeCategory.Nesting,
             languages: ["json"],
         },
         {
-            expression: "block_node",
-            metrics: [],
-            type: "statement",
+            type_name: "block_node",
             category: NodeTypeCategory.Nesting,
             languages: ["yaml"],
         },

--- a/src/parser/metrics/MaxNestingLevel.ts
+++ b/src/parser/metrics/MaxNestingLevel.ts
@@ -1,4 +1,4 @@
-import { ExpressionMetricMapping, NodeTypeCategory } from "../helper/Model";
+import { NodeTypeConfig, NodeTypeCategory } from "../helper/Model";
 import { FileMetric, Metric, MetricResult, ParsedFile } from "./Metric";
 import { debuglog, DebugLoggerFunction } from "node:util";
 import { TreeCursor } from "tree-sitter";
@@ -17,10 +17,10 @@ export class MaxNestingLevel implements Metric {
      * Constructs a new instance of {@link MaxNestingLevel}.
      * @param allNodeTypes List of all configured syntax node types.
      */
-    constructor(allNodeTypes: ExpressionMetricMapping[]) {
+    constructor(allNodeTypes: NodeTypeConfig[]) {
         for (const nodeType of allNodeTypes) {
             if (nodeType.category === NodeTypeCategory.Nesting) {
-                this.nodeTypesToCount.push(nodeType.expression);
+                this.nodeTypesToCount.push(nodeType.type_name);
             }
         }
     }

--- a/src/parser/metrics/RealLinesOfCode.ts
+++ b/src/parser/metrics/RealLinesOfCode.ts
@@ -1,7 +1,7 @@
-import { ExpressionMetricMapping } from "../helper/Model";
+import { NodeTypeCategory, NodeTypeConfig } from "../helper/Model";
 import { FileMetric, Metric, MetricResult, ParsedFile } from "./Metric";
 import { SyntaxNode, TreeCursor } from "tree-sitter";
-import { getExpressionsByCategory } from "../helper/Helper";
+import { getNodeTypeNamesByCategory } from "../helper/Helper";
 import { debuglog, DebugLoggerFunction } from "node:util";
 import { Language } from "../helper/Language";
 
@@ -19,9 +19,9 @@ export class RealLinesOfCode implements Metric {
      * Constructs a new instance of {@link RealLinesOfCode}.
      * @param allNodeTypes List of all configured syntax node types.
      */
-    constructor(allNodeTypes: ExpressionMetricMapping[]) {
+    constructor(allNodeTypes: NodeTypeConfig[]) {
         this.commentStatementsSet = new Set(
-            getExpressionsByCategory(allNodeTypes, this.getName(), "comment"),
+            getNodeTypeNamesByCategory(allNodeTypes, NodeTypeCategory.Comment),
         );
     }
 

--- a/src/parser/metrics/RealLinesOfCode.ts
+++ b/src/parser/metrics/RealLinesOfCode.ts
@@ -1,7 +1,7 @@
 import { NodeTypeCategory, NodeTypeConfig } from "../helper/Model";
 import { FileMetric, Metric, MetricResult, ParsedFile } from "./Metric";
 import { SyntaxNode, TreeCursor } from "tree-sitter";
-import { getNodeTypeNamesByCategory } from "../helper/Helper";
+import { getNodeTypeNamesByCategories } from "../helper/Helper";
 import { debuglog, DebugLoggerFunction } from "node:util";
 import { Language } from "../helper/Language";
 
@@ -21,7 +21,7 @@ export class RealLinesOfCode implements Metric {
      */
     constructor(allNodeTypes: NodeTypeConfig[]) {
         this.commentStatementsSet = new Set(
-            getNodeTypeNamesByCategory(allNodeTypes, NodeTypeCategory.Comment),
+            getNodeTypeNamesByCategories(allNodeTypes, NodeTypeCategory.Comment),
         );
     }
 

--- a/src/parser/metrics/coupling/Coupling.ts
+++ b/src/parser/metrics/coupling/Coupling.ts
@@ -1,4 +1,4 @@
-import { ExpressionMetricMapping } from "../../helper/Model";
+import { NodeTypeConfig } from "../../helper/Model";
 import { FullyQTN } from "../../resolver/fullyQualifiedTypeNames/AbstractCollector";
 import {
     UnresolvedCallExpression,
@@ -36,7 +36,7 @@ export class Coupling implements CouplingMetric {
 
     constructor(
         config: Configuration,
-        allNodeTypes: ExpressionMetricMapping[],
+        allNodeTypes: NodeTypeConfig[],
         namespaceCollector: NamespaceCollector,
         usageCollector: UsagesCollector,
         publicAccessorCollector: PublicAccessorCollector,


### PR DESCRIPTION
# Rework node types config, renamed "expression" to "node type"

Closes #145
Closes #103
Closes #54

## Description

Refactors the nodeTypesConfig.json. We now no longer have a direct mapping between node type and metric, but a "category" to which a node type belongs that might be relevant for one or multiple metrics. This is especially helpful when defining new metrics or refining the definition of old metrics. For example, there are now distinct categories for "class_definition", "interface_definition", "if", "logical_binary_expression", etc., so that we can redefine e.g. the "classes" or "complexity" metric quite easily.
Changed the Queries in `src/parser/queries/QueryStatements.ts` and all their uses accordingly. By reading all information out of a `NodeTypesConfig`-object by default, using these queries should be less error prone now, too.

This also introdues a more consistent naming by changing "expression" to "node type" or "type name" where "expression" was used as a synonym to these terms to avoid confusion. The obsolete field `type` was removed. 
The file `src/parser/helper/Model.ts` now includes documentation about the meaning of the fields in the `nodeTypesConfig.json`.

This does not touch the issue #213 and #222. Intries for node types that touch these issues are either unchanged if there is no mapping or mapped as "interface_definition".

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
* [x]  All TODOs related to this PR have been closed
* [x]  There are automated tests for newly written code and bug fixes
* [x]  All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
* [x]  Documentation ([README.md](https://github.com/MaibornWolff/metric-gardener/blob/main/README.md), [UPDATE_GRAMMARS.md](https://github.com/MaibornWolff/metric-gardener/blob/main/UPDATE_GRAMMARS.md)) has been updated
