### PR TITLE
Add documentation for C++ and C

### DIFF
--- a/CAndCpp.md
+++ b/CAndCpp.md
@@ -1,6 +1,6 @@
-# File Metrics for C++
+# File Metrics for C and C++
 
-This document outlines the definition of file metrics for C++.
+This document outlines the definition of file metrics for C and C++.
 
 ### complexity
 

--- a/CAndCpp.md
+++ b/CAndCpp.md
@@ -21,6 +21,7 @@ It does **not** count:
 
 -   preprocessor directives like `#if`, `#ifdef` or `#ifndef`
 -   `for-each`, `copy_if` function calls from the Standard Template Libraries or other built-in functions
+-   `xor` (alternative syntax `^`) operators
 
 ### functions
 

--- a/Cpp.md
+++ b/Cpp.md
@@ -1,0 +1,51 @@
+# File Metrics for C++
+
+This document outlines the definition of file metrics for C++.
+
+### complexity
+
+The "complexity" metric counts:
+
+-   `if` and `else if` statements
+-   ternary expressions
+-   `for` loops with following syntaxes:
+    -   `for (type variableName : arrayName) {...}`
+    -   `for (statement 1; statement 2; statement 3) {...}`
+-   `while` and `do...while` loops
+-   `case` labels in switch-statements
+-   `catch` blocks and `except` clauses in Structured Exception Handling (SEH)
+-   logical binary operations `&&` and `||` as well as their alternative spellings `and` and `or`
+-   everything counted for the "functions" metric
+
+It does **not** count:
+
+-   preprocessor directives like `#if`, `#ifdef` or `#ifndef`
+-   `for-each`, `copy_if` function calls from the Standard Template Libraries or other built-in functions
+
+### functions
+
+The "functions" metric counts:
+
+-   method declarations and definitions in `class`, `struct` and `union`
+-   constructors and destructors in `class`, `struct` and `union`
+-   lambda functions
+
+### classes
+
+The "classes" metric counts:
+
+-   definitions of `class`, `struct` and `union`
+-   enums (`enum`,`enum class` and `enum struct`) and also opaque enums
+-   `typedef` usages, which contain implementation {...}:
+    -   `typedef struct {...} alias_name`
+    -   `typedef union {...} alias_name`
+    -   `typedef enum {...} alias_name`
+
+It does **not** count:
+
+-   forward declarations of `class`,`struct` and `union`
+-   other usages of `typedef` not listed above
+
+### lines_of_code, comment_lines and real_lines_of_code
+
+see [README.md](README.md)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This is quite slow and can take up to one or two hours but can provide good resu
 -   [TypeScript and TSX](https://github.com/MaibornWolff/metric-gardener/blob/main/TS_TSX.md)
 -   Java
 -   C#
--   C++
+-   [C++](Cpp.md)
 -   Python
 -   JavaScript
 -   Kotlin

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This is quite slow and can take up to one or two hours but can provide good resu
 -   [TypeScript and TSX](https://github.com/MaibornWolff/metric-gardener/blob/main/TS_TSX.md)
 -   Java
 -   C#
--   [C++](Cpp.md)
+-   [C++](CAndCpp.md)
 -   Python
 -   JavaScript
 -   Kotlin
@@ -56,7 +56,7 @@ This is quite slow and can take up to one or two hours but can provide good resu
 -   Rust
 -   Bash (the binary logical operators -o for "or" and -a for "and" are currently not evaluated due to issues with tree-sitter-bash. For the same reason, the && and || operators are not evaluated if placed after the first heredoc delimiter. Default labels in Switch-statement are treated as regular case labels.)
 -   Flow-annotated JavaScript
--   C (take a look at the CLI option [`parse-h-as-c`](#command-line-options-for-the-parse-command) or [`parse-some-h-as-c`](#command-line-options-for-the-parse-command) for parsing `.h` C headers as C)
+-   [C](CAndCpp.md) (take a look at the CLI option [`parse-h-as-c`](#command-line-options-for-the-parse-command) or [`parse-some-h-as-c`](#command-line-options-for-the-parse-command) for parsing `.h` C headers as C)
 
 ### Supported File Metrics
 

--- a/resources/c++/logical_operation.cpp
+++ b/resources/c++/logical_operation.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+
+int main() {
+    int x = 1;
+    int y = 0;
+    if (x > 0 and y > 0) {
+        std::cout << "Both x and y are positive." << std::endl;
+    }
+
+    if (x > 0 or y > 0) {
+        std::cout << "At least one of x and y is positive." << std::endl;
+    }
+
+    if (x > 0 && y > 0) {
+        std::cout << "Both x and y are positive." << std::endl;
+    }
+
+    if (x > 0 || y > 0) {
+        std::cout << "At least one of x and y is positive." << std::endl;
+    }
+
+    if ((x > 0) ^ (y > 0)) {
+        std::cout << "Exactly one of x and y is positive." << std::endl;
+    }
+    if ((x > 0) xor (y > 0)) {
+            std::cout << "Exactly one of x and y is positive." << std::endl;
+        }
+
+    return 0;
+}

--- a/src/parser/config/nodeTypesConfig.json
+++ b/src/parser/config/nodeTypesConfig.json
@@ -3029,7 +3029,7 @@
     },
     {
         "type_name": "binary_expression_xor",
-        "category": "logical_binary_expression",
+        "category": "",
         "languages": ["php", "cpp"],
         "grammar_type_name": "binary_expression",
         "operator": "xor"

--- a/test/metric-end-results/CPlusPlusMetrics.test.ts
+++ b/test/metric-end-results/CPlusPlusMetrics.test.ts
@@ -65,6 +65,14 @@ describe("C++ metrics tests", () => {
                 6,
             );
         });
+
+        it("should count only &&, ||, and and or logical operations, not xor or ^", () => {
+            testFileMetric(
+                cppTestResourcesPath + "logical_operation.cpp",
+                FileMetric.complexity,
+                11,
+            );
+        });
     });
 
     describe("parses C++ classes metric", () => {


### PR DESCRIPTION
# Add documentation for C++ and C
Closes: #239

## Description
- Add documentation for C and C++
- Minor fix: `xor` operation should not be counted as logical operator, because its bitwise.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
* [ ]  All TODOs related to this PR have been closed
* [x]  There are automated tests for newly written code and bug fixes
* [x]  All bugs discovered while working on this PR have been submitted as issues (if not already an open issue)
* [x]  Documentation ([README.md](https://github.com/MaibornWolff/metric-gardener/blob/main/README.md), [UPDATE_GRAMMARS.md](https://github.com/MaibornWolff/metric-gardener/blob/main/UPDATE_GRAMMARS.md)) has been updated