### PR TITLE
Remove duplicate metric name from FileMetricResults

### DIFF
--- a/src/commands/outputMetrics.test.ts
+++ b/src/commands/outputMetrics.test.ts
@@ -11,14 +11,14 @@ describe("outputMetrics", () => {
         });
 
         it("when metrics are present", () => {
-            const file1MetricResults = new Map<string, MetricResult>();
-            file1MetricResults.set("metric1", { metricName: "metric1", metricValue: 42 });
-            file1MetricResults.set("metric2", { metricName: "metric2", metricValue: 43 });
+            const file1MetricResults: MetricResult[] = [];
+            file1MetricResults.push({ metricName: "metric1", metricValue: 42 });
+            file1MetricResults.push({ metricName: "metric2", metricValue: 43 });
 
-            const file2MetricResults = new Map<string, MetricResult>();
-            file2MetricResults.set("metric1", { metricName: "metric1", metricValue: 44 });
-            const file2MetricErrors = new Map<string, MetricError>();
-            file2MetricErrors.set("metric2", { metricName: "metric2", error: new Error("Buh!") });
+            const file2MetricResults: MetricResult[] = [];
+            file2MetricResults.push({ metricName: "metric1", metricValue: 44 });
+            const file2MetricErrors: MetricError[] = [];
+            file2MetricErrors.push({ metricName: "metric2", error: new Error("Buh!") });
 
             const fileMetrics = new Map([
                 [
@@ -26,7 +26,7 @@ describe("outputMetrics", () => {
                     {
                         fileType: FileType.SourceCode,
                         metricResults: file1MetricResults,
-                        metricErrors: new Map(),
+                        metricErrors: [],
                     },
                 ],
                 [

--- a/src/commands/outputMetrics.ts
+++ b/src/commands/outputMetrics.ts
@@ -85,12 +85,12 @@ function buildOutputObject(
 
     for (const [filePath, fileMetricResults] of fileMetrics.entries()) {
         const metrics = {};
-        if (fileMetricResults.metricErrors.size > 0) {
-            metricErrorsPerFile.set(filePath, fileMetricResults.metricErrors.values());
+        if (fileMetricResults.metricErrors.length > 0) {
+            metricErrorsPerFile.set(filePath, fileMetricResults.metricErrors);
         }
 
-        for (const [metricName, metricValue] of fileMetricResults.metricResults.entries()) {
-            metrics[metricName] = metricValue.metricValue;
+        for (const metricResult of fileMetricResults.metricResults) {
+            metrics[metricResult.metricName] = metricResult.metricValue;
         }
 
         const outputNode: OutputNode = {

--- a/src/parser/GenericParser.test.ts
+++ b/src/parser/GenericParser.test.ts
@@ -65,10 +65,7 @@ async function mockedMetricsCalculator(
 ): Promise<[SourceFile, FileMetricResults]> {
     const file = await parsedFilePromise;
     if (isErrorFile(file)) {
-        return [
-            file,
-            { fileType: file.fileType, metricResults: new Map(), metricErrors: new Map() },
-        ];
+        return [file, { fileType: file.fileType, metricResults: [], metricErrors: [] }];
     }
     return [file, expectedFileMetricsResults];
 }
@@ -106,10 +103,8 @@ function spyOnCouplingCalculatorNoOp() {
 
 const expectedFileMetricsResults: FileMetricResults = {
     fileType: FileType.SourceCode,
-    metricResults: new Map([
-        [FileMetric.linesOfCode, { metricName: FileMetric.linesOfCode, metricValue: 5 }],
-    ]),
-    metricErrors: new Map(),
+    metricResults: [{ metricName: FileMetric.linesOfCode, metricValue: 5 }],
+    metricErrors: [],
 };
 
 let parser: Parser;
@@ -275,31 +270,14 @@ describe("GenericParser.calculateMetrics()", () => {
         mockFindFilesAsync();
         mockTreeParserParse();
 
-        const metricErrors: Map<string, MetricError> = new Map([
-            [
-                FileMetric.linesOfCode,
-                {
-                    metricName: FileMetric.linesOfCode,
-                    error: new Error("Buuuh!"),
-                },
-            ],
-        ]);
-
         const errorMetricsResults: FileMetricResults = {
             fileType: FileType.SourceCode,
-            metricResults: new Map(),
-            metricErrors,
+            metricResults: [],
+            metricErrors: [{ metricName: FileMetric.linesOfCode, error: new Error("Buuuh!") }],
         };
 
         spyOnMetricCalculator().mockImplementation(async (parsedFilePromise) => {
-            return [
-                await parsedFilePromise,
-                {
-                    fileType: FileType.SourceCode,
-                    metricResults: new Map(),
-                    metricErrors,
-                },
-            ];
+            return [await parsedFilePromise, errorMetricsResults];
         });
 
         const errorSpy = spyOnConsoleErrorNoOp();
@@ -327,20 +305,15 @@ describe("GenericParser.calculateMetrics()", () => {
         mockFindFilesAsync(mockedFindTwoFilesAsync);
         mockTreeParserParse();
 
-        const metricErrors: Map<string, MetricError> = new Map([
-            [
-                FileMetric.linesOfCode,
+        const errorMetricsResults: FileMetricResults = {
+            fileType: FileType.SourceCode,
+            metricResults: [],
+            metricErrors: [
                 {
                     metricName: FileMetric.linesOfCode,
                     error: new Error("I only accept cpp files!"),
                 },
             ],
-        ]);
-
-        const errorMetricsResults: FileMetricResults = {
-            fileType: FileType.SourceCode,
-            metricResults: new Map(),
-            metricErrors,
         };
 
         spyOnMetricCalculator().mockImplementation(async (parsedFilePromise) => {
@@ -379,32 +352,21 @@ describe("GenericParser.calculateMetrics()", () => {
         mockFindFilesAsync(mockedFindTwoFilesAsync);
         mockTreeParserParse();
 
-        const metricResults = new Map<string, MetricResult>([
-            [FileMetric.linesOfCode, { metricName: FileMetric.linesOfCode, metricValue: 5 }],
-            [
-                FileMetric.realLinesOfCode,
-                { metricName: FileMetric.realLinesOfCode, metricValue: 3 },
-            ],
-        ]);
+        const metricResults: MetricResult[] = [
+            { metricName: FileMetric.linesOfCode, metricValue: 5 },
+            { metricName: FileMetric.realLinesOfCode, metricValue: 3 },
+        ];
 
-        const metricErrors = new Map<string, MetricError>([
-            [
-                FileMetric.classes,
-                {
-                    metricName: FileMetric.classes,
-                    error: new Error("Classes metric is to difficult for this program!"),
-                },
-            ],
-            [
-                FileMetric.functions,
-                {
-                    metricName: FileMetric.functions,
-                    error: new Error(
-                        "Unable to call functions, because, well, it does not work, ok??",
-                    ),
-                },
-            ],
-        ]);
+        const metricErrors: MetricError[] = [
+            {
+                metricName: FileMetric.classes,
+                error: new Error("Classes metric is to difficult for this program!"),
+            },
+            {
+                metricName: FileMetric.functions,
+                error: new Error("Unable to call functions, because, well, it does not work, ok??"),
+            },
+        ];
 
         const partialErrorMetricsResults: FileMetricResults = {
             fileType: FileType.SourceCode,

--- a/src/parser/GenericParser.ts
+++ b/src/parser/GenericParser.ts
@@ -101,7 +101,7 @@ export class GenericParser {
                     fileMetrics.set(printPath, fileMetricResults);
 
                     // Inform about errors that occurred while calculating (some) metrics on the syntax tree
-                    for (const metricError of fileMetricResults.metricErrors.values()) {
+                    for (const metricError of fileMetricResults.metricErrors) {
                         console.error(
                             "Error while calculating the metric " +
                                 metricError.metricName +

--- a/src/parser/MetricCalculator.test.ts
+++ b/src/parser/MetricCalculator.test.ts
@@ -1,6 +1,12 @@
 import { expect, jest } from "@jest/globals";
 import { MetricCalculator } from "./MetricCalculator";
-import { spyOnConsoleErrorNoOp } from "../../test/metric-end-results/TestHelper";
+import {
+    expectError,
+    expectMetric,
+    expectNoError,
+    expectNoMetric,
+    spyOnConsoleErrorNoOp,
+} from "../../test/metric-end-results/TestHelper";
 import {
     ErrorFile,
     FileMetric,
@@ -127,31 +133,13 @@ describe("MetricCalculator.calculateMetrics()", () => {
         // then
         expect(sourceFile).toEqual(parsedFile);
         expect(fileMetricResults.fileType).toEqual(FileType.SourceCode);
-        expect(fileMetricResults.metricResults.get(FileMetric.classes)).toEqual({
-            metricName: FileMetric.classes,
-            metricValue: 1,
-        });
-        expect(fileMetricResults.metricResults.get(FileMetric.commentLines)).toEqual({
-            metricName: FileMetric.commentLines,
-            metricValue: 2,
-        });
-        expect(fileMetricResults.metricResults.get(FileMetric.complexity)).toEqual({
-            metricName: FileMetric.complexity,
-            metricValue: 3,
-        });
-        expect(fileMetricResults.metricResults.get(FileMetric.functions)).toEqual({
-            metricName: FileMetric.functions,
-            metricValue: 4,
-        });
-        expect(fileMetricResults.metricResults.get(FileMetric.linesOfCode)).toEqual({
-            metricName: FileMetric.linesOfCode,
-            metricValue: 5,
-        });
-        expect(fileMetricResults.metricResults.get(FileMetric.realLinesOfCode)).toEqual({
-            metricName: FileMetric.realLinesOfCode,
-            metricValue: 7,
-        });
-        expect(fileMetricResults.metricResults.has(FileMetric.maxNestingLevel)).toEqual(false);
+        expectMetric(fileMetricResults, FileMetric.classes, 1);
+        expectMetric(fileMetricResults, FileMetric.commentLines, 2);
+        expectMetric(fileMetricResults, FileMetric.complexity, 3);
+        expectMetric(fileMetricResults, FileMetric.functions, 4);
+        expectMetric(fileMetricResults, FileMetric.linesOfCode, 5);
+        expectMetric(fileMetricResults, FileMetric.realLinesOfCode, 7);
+        expectNoMetric(fileMetricResults, FileMetric.maxNestingLevel);
     });
 
     it("should calculate lines of code and maximum nesting level for a JSON file", async () => {
@@ -172,19 +160,13 @@ describe("MetricCalculator.calculateMetrics()", () => {
         // then
         expect(sourceFile).toEqual(parsedFile);
         expect(fileMetricResults.fileType).toEqual(FileType.StructuredText);
-        expect(fileMetricResults.metricResults.has(FileMetric.classes)).toEqual(false);
-        expect(fileMetricResults.metricResults.has(FileMetric.commentLines)).toEqual(false);
-        expect(fileMetricResults.metricResults.has(FileMetric.complexity)).toEqual(false);
-        expect(fileMetricResults.metricResults.has(FileMetric.functions)).toEqual(false);
-        expect(fileMetricResults.metricResults.get(FileMetric.linesOfCode)).toEqual({
-            metricName: FileMetric.linesOfCode,
-            metricValue: 5,
-        });
-        expect(fileMetricResults.metricResults.has(FileMetric.realLinesOfCode)).toEqual(false);
-        expect(fileMetricResults.metricResults.get(FileMetric.maxNestingLevel)).toEqual({
-            metricName: FileMetric.maxNestingLevel,
-            metricValue: 6,
-        });
+        expectNoMetric(fileMetricResults, FileMetric.classes);
+        expectNoMetric(fileMetricResults, FileMetric.commentLines);
+        expectNoMetric(fileMetricResults, FileMetric.complexity);
+        expectNoMetric(fileMetricResults, FileMetric.functions);
+        expectMetric(fileMetricResults, FileMetric.linesOfCode, 5);
+        expectNoMetric(fileMetricResults, FileMetric.realLinesOfCode);
+        expectMetric(fileMetricResults, FileMetric.maxNestingLevel, 6);
     });
 
     it("should calculate lines of code for a text file", async () => {
@@ -203,16 +185,13 @@ describe("MetricCalculator.calculateMetrics()", () => {
         // then
         expect(sourceFile).toEqual(unsupportedFile);
         expect(fileMetricResults.fileType).toEqual(FileType.Unsupported);
-        expect(fileMetricResults.metricResults.has(FileMetric.classes)).toEqual(false);
-        expect(fileMetricResults.metricResults.has(FileMetric.commentLines)).toEqual(false);
-        expect(fileMetricResults.metricResults.has(FileMetric.complexity)).toEqual(false);
-        expect(fileMetricResults.metricResults.has(FileMetric.functions)).toEqual(false);
-        expect(fileMetricResults.metricResults.get(FileMetric.linesOfCode)).toEqual({
-            metricName: FileMetric.linesOfCode,
-            metricValue: 8,
-        });
-        expect(fileMetricResults.metricResults.has(FileMetric.realLinesOfCode)).toEqual(false);
-        expect(fileMetricResults.metricResults.has(FileMetric.maxNestingLevel)).toEqual(false);
+        expectNoMetric(fileMetricResults, FileMetric.classes);
+        expectNoMetric(fileMetricResults, FileMetric.commentLines);
+        expectNoMetric(fileMetricResults, FileMetric.complexity);
+        expectNoMetric(fileMetricResults, FileMetric.functions);
+        expectMetric(fileMetricResults, FileMetric.linesOfCode, 8);
+        expectNoMetric(fileMetricResults, FileMetric.realLinesOfCode);
+        expectNoMetric(fileMetricResults, FileMetric.maxNestingLevel);
     });
 
     it("should return an empty map of metrics when the source file is an error file", async () => {
@@ -234,7 +213,7 @@ describe("MetricCalculator.calculateMetrics()", () => {
         // then
         const expectedResult: [SourceFile, FileMetricResults] = [
             errorFile,
-            { fileType: FileType.Error, metricResults: new Map(), metricErrors: new Map() },
+            { fileType: FileType.Error, metricResults: [], metricErrors: [] },
         ];
         expect(result).toEqual(expectedResult);
     });
@@ -257,40 +236,38 @@ describe("MetricCalculator.calculateMetrics()", () => {
         // then
         expect(sourceFile).toEqual(parsedFile);
         expect(fileMetricResults.fileType).toEqual(FileType.SourceCode);
+        expectNoMetric(fileMetricResults, FileMetric.classes);
+        expectNoMetric(fileMetricResults, FileMetric.commentLines);
+        expectNoMetric(fileMetricResults, FileMetric.complexity);
+        expectMetric(fileMetricResults, FileMetric.functions, 1);
+        expectMetric(fileMetricResults, FileMetric.linesOfCode, 2);
+        expectNoMetric(fileMetricResults, FileMetric.realLinesOfCode);
+        expectNoMetric(fileMetricResults, FileMetric.maxNestingLevel);
 
-        expect(fileMetricResults.metricResults.has(FileMetric.classes)).toEqual(false);
-        expect(fileMetricResults.metricResults.has(FileMetric.commentLines)).toEqual(false);
-        expect(fileMetricResults.metricResults.has(FileMetric.complexity)).toEqual(false);
-        expect(fileMetricResults.metricResults.get(FileMetric.functions)).toEqual({
-            metricName: FileMetric.functions,
-            metricValue: 1,
-        });
-        expect(fileMetricResults.metricResults.get(FileMetric.linesOfCode)).toEqual({
-            metricName: FileMetric.linesOfCode,
-            metricValue: 2,
-        });
-        expect(fileMetricResults.metricResults.has(FileMetric.realLinesOfCode)).toEqual(false);
-        expect(fileMetricResults.metricResults.has(FileMetric.maxNestingLevel)).toEqual(false);
+        expectError(
+            fileMetricResults,
+            FileMetric.classes,
+            new Error("something went wrong when calculating classes metric"),
+        );
+        expectError(
+            fileMetricResults,
+            FileMetric.commentLines,
+            new Error("something went wrong when calculating commentLines metric"),
+        );
+        expectError(
+            fileMetricResults,
+            FileMetric.complexity,
+            new Error("something went wrong when calculating complexity metric"),
+        );
+        expectNoError(fileMetricResults, FileMetric.functions);
+        expectNoError(fileMetricResults, FileMetric.linesOfCode);
+        expectError(
+            fileMetricResults,
+            FileMetric.realLinesOfCode,
+            new Error("something went wrong when calculating realLinesOfCode metric"),
+        );
 
-        expect(fileMetricResults.metricErrors.get(FileMetric.classes)).toEqual({
-            metricName: FileMetric.classes,
-            error: new Error("something went wrong when calculating classes metric"),
-        });
-        expect(fileMetricResults.metricErrors.get(FileMetric.commentLines)).toEqual({
-            metricName: FileMetric.commentLines,
-            error: new Error("something went wrong when calculating commentLines metric"),
-        });
-        expect(fileMetricResults.metricErrors.get(FileMetric.complexity)).toEqual({
-            metricName: FileMetric.complexity,
-            error: new Error("something went wrong when calculating complexity metric"),
-        });
-        expect(fileMetricResults.metricErrors.has(FileMetric.functions)).toEqual(false);
-        expect(fileMetricResults.metricErrors.has(FileMetric.linesOfCode)).toEqual(false);
-        expect(fileMetricResults.metricErrors.get(FileMetric.realLinesOfCode)).toEqual({
-            metricName: FileMetric.realLinesOfCode,
-            error: new Error("something went wrong when calculating realLinesOfCode metric"),
-        });
         // Should not have been tried to calculate on source code in the first place:
-        expect(fileMetricResults.metricErrors.has(FileMetric.maxNestingLevel)).toEqual(false);
+        expectNoMetric(fileMetricResults, FileMetric.maxNestingLevel);
     });
 });

--- a/src/parser/metrics/Metric.ts
+++ b/src/parser/metrics/Metric.ts
@@ -19,8 +19,8 @@ export enum FileMetric {
  */
 export interface FileMetricResults {
     fileType: FileType;
-    metricResults: Map<string, MetricResult>;
-    metricErrors: Map<string, MetricError>;
+    metricResults: MetricResult[];
+    metricErrors: MetricError[];
 }
 
 /**

--- a/test/metric-end-results/TestHelper.ts
+++ b/test/metric-end-results/TestHelper.ts
@@ -75,7 +75,7 @@ export function sortCouplingResults(couplingResult: CouplingResult) {
  * @param inputPath Path to test source file.
  * @param metric Name of the metric.
  * @param expected Expected test result.
- * */
+ */
 export async function parseAndTestFileMetric(
     inputPath: string,
     metric: FileMetric,
@@ -84,9 +84,8 @@ export async function parseAndTestFileMetric(
     const realInputPath = fs.realpathSync(inputPath);
     const parser = new GenericParser(getTestConfiguration(realInputPath));
     const results = await parser.calculateMetrics();
-    expect(results.fileMetrics.get(realInputPath)?.metricResults.get(metric)?.metricValue).toBe(
-        expected,
-    );
+    const metricResults = results.fileMetrics.get(realInputPath);
+    expectMetric(metricResults, metric, expected);
 }
 
 /**
@@ -110,7 +109,7 @@ export async function parseAllFileMetrics(inputPath: string, parseHAsC = false) 
  * @param inputPath Relative or absolute path to test source file.
  * @param metric Name of the metric.
  * @param expected Expected metric value.
- * */
+ */
 export function expectFileMetric(
     results: Map<string, FileMetricResults>,
     inputPath: string,
@@ -118,7 +117,58 @@ export function expectFileMetric(
     expected: number,
 ) {
     const realInputPath = fs.realpathSync(inputPath);
-    expect(results.get(realInputPath)?.metricResults.get(metric)?.metricValue).toBe(expected);
+    const metricResults = results.get(realInputPath);
+    expectMetric(metricResults, metric, expected);
+}
+
+/**
+ * Tests if a specific metric has been calculated correctly.
+ * @param results The actual results of the metric calculation.
+ * @param metric Name of the metric.
+ * @param expected Expected metric value.
+ */
+export function expectMetric(
+    results: FileMetricResults | undefined,
+    metric: FileMetric,
+    expected: number,
+) {
+    const metricResults = results?.metricResults;
+    const metricValue = metricResults?.find(({ metricName }) => metricName === metric)?.metricValue;
+    expect(metricValue).toBe(expected);
+}
+
+/**
+ * Tests if a specific metric has not been calculated.
+ * @param results The actual results of the metric calculation.
+ * @param metric Name of the metric.
+ */
+export function expectNoMetric(results: FileMetricResults | undefined, metric: FileMetric) {
+    expect(results?.metricResults.find(({ metricName }) => metricName === metric)).toBeUndefined();
+}
+
+/**
+ * Tests if a specific metric has an expected error.
+ * @param results The actual results of the metric calculation.
+ * @param metric Name of the metric.
+ * @param expected Expected error.
+ */
+export function expectError(
+    results: FileMetricResults | undefined,
+    metric: FileMetric,
+    expected: Error,
+) {
+    const metricErrors = results?.metricErrors;
+    const error = metricErrors?.find(({ metricName }) => metricName === metric)?.error;
+    expect(error).toEqual(expected);
+}
+
+/**
+ * Test if no error occurred while calculating a specific metric.
+ * @param results The actual results of the metric calculation.
+ * @param metric Name of the metric.
+ */
+export function expectNoError(results: FileMetricResults | undefined, metric: FileMetric) {
+    expect(results?.metricErrors.find(({ metricName }) => metricName === metric)).toBeUndefined();
 }
 
 /**


### PR DESCRIPTION
# Remove duplicate metric name from FileMetricResults

Closes: #253 

## Description

This makes the code easier to read and write.
I did not notice a significant increase in tests running time.

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
* [x]  All TODOs related to this PR have been closed
* [x]  There are automated tests for newly written code and bug fixes

