### PR TITLE
Do not count `xor` as complexity for C++

### DIFF
--- a/resources/c++/logical_operation.cpp
+++ b/resources/c++/logical_operation.cpp
@@ -3,6 +3,7 @@
 int main() {
     int x = 1;
     int y = 0;
+
     if (x > 0 and y > 0) {
         std::cout << "Both x and y are positive." << std::endl;
     }
@@ -22,9 +23,10 @@ int main() {
     if ((x > 0) ^ (y > 0)) {
         std::cout << "Exactly one of x and y is positive." << std::endl;
     }
+
     if ((x > 0) xor (y > 0)) {
-            std::cout << "Exactly one of x and y is positive." << std::endl;
-        }
+        std::cout << "Exactly one of x and y is positive." << std::endl;
+    }
 
     return 0;
 }

--- a/resources/c++/logical_operation.cpp
+++ b/resources/c++/logical_operation.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+
+int main() {
+    int x = 1;
+    int y = 0;
+    if (x > 0 and y > 0) {
+        std::cout << "Both x and y are positive." << std::endl;
+    }
+
+    if (x > 0 or y > 0) {
+        std::cout << "At least one of x and y is positive." << std::endl;
+    }
+
+    if (x > 0 && y > 0) {
+        std::cout << "Both x and y are positive." << std::endl;
+    }
+
+    if (x > 0 || y > 0) {
+        std::cout << "At least one of x and y is positive." << std::endl;
+    }
+
+    if ((x > 0) ^ (y > 0)) {
+        std::cout << "Exactly one of x and y is positive." << std::endl;
+    }
+    if ((x > 0) xor (y > 0)) {
+            std::cout << "Exactly one of x and y is positive." << std::endl;
+        }
+
+    return 0;
+}

--- a/resources/php/logical-operations.php
+++ b/resources/php/logical-operations.php
@@ -3,4 +3,3 @@
 $result1 = true && false; // +1 complexity
 $result2 = true || false; // +1 complexity
 $result3 = true xor false; // +1 complexity
-

--- a/resources/php/logical_operations.php
+++ b/resources/php/logical_operations.php
@@ -1,0 +1,6 @@
+<?php
+
+$result1 = true && false; // +1 complexity
+$result2 = true || false; // +1 complexity
+$result3 = true xor false; // +1 complexity
+

--- a/src/parser/config/nodeTypesConfig.json
+++ b/src/parser/config/nodeTypesConfig.json
@@ -3030,6 +3030,7 @@
     {
         "type_name": "binary_expression_xor",
         "category": "logical_binary_expression",
+        "deactivated_for_languages": ["cpp"],
         "languages": ["php", "cpp"],
         "grammar_type_name": "binary_expression",
         "operator": "xor"

--- a/test/metric-end-results/CPlusPlusMetrics.test.ts
+++ b/test/metric-end-results/CPlusPlusMetrics.test.ts
@@ -65,6 +65,14 @@ describe("C++ metrics tests", () => {
                 6,
             );
         });
+
+        it("should count only &&, ||, and and or logical operations, not xor or ^", () => {
+            testFileMetric(
+                cppTestResourcesPath + "logical_operation.cpp",
+                FileMetric.complexity,
+                11,
+            );
+        });
     });
 
     describe("parses C++ classes metric", () => {

--- a/test/metric-end-results/PHPMetrics.test.ts
+++ b/test/metric-end-results/PHPMetrics.test.ts
@@ -53,6 +53,14 @@ describe("PHP metrics tests", () => {
         it("should count loops properly", () => {
             testFileMetric(phpTestResourcesPath + "loops.php", FileMetric.complexity, 4);
         });
+
+        it("should count the logical operations &&, || and xor", () => {
+            testFileMetric(
+                phpTestResourcesPath + "logical_operations.php",
+                FileMetric.complexity,
+                3,
+            );
+        });
     });
 
     describe("parses PHP classes metric", () => {

--- a/test/metric-end-results/PHPMetrics.test.ts
+++ b/test/metric-end-results/PHPMetrics.test.ts
@@ -56,7 +56,7 @@ describe("PHP metrics tests", () => {
 
         it("should count the logical operations &&, || and xor", () => {
             testFileMetric(
-                phpTestResourcesPath + "logical_operations.php",
+                phpTestResourcesPath + "logical-operations.php",
                 FileMetric.complexity,
                 3,
             );


### PR DESCRIPTION
# Do not count `xor` as complexity for C++
Closes: #267 

## Description
-  deactivate `xor`-node for C++  
- add tests to ensure that `xor` is counted as "complexity" for PHP but not for C++
## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:
* [x]  There are automated tests for newly written code and bug fixes
* [ ]  Documentation ([README.md](https://github.com/MaibornWolff/metric-gardener/blob/main/README.md), [UPDATE_GRAMMARS.md](https://github.com/MaibornWolff/metric-gardener/blob/main/docs/UPDATE_GRAMMARS.md)) has been updated
