### PR TITLE
Fix wrong file ending when compressing

### DIFF
--- a/src/commands/outputMetrics.ts
+++ b/src/commands/outputMetrics.ts
@@ -52,10 +52,8 @@ export function outputAsJson(
     const outputString = JSON.stringify(output).toString();
 
     if (compress) {
-        dumpCompressed(
-            outputString,
-            outputFilePath.endsWith(".gz") ? outputFilePath : outputFilePath + ".gz",
-        );
+        outputFilePath = outputFilePath.endsWith(".gz") ? outputFilePath : outputFilePath + ".gz";
+        dumpCompressed(outputString, outputFilePath);
     } else {
         fs.writeFileSync(outputFilePath, outputString);
     }


### PR DESCRIPTION
# Fix wrong file ending when compressing

Closes: #293

## Description

Fixed outputting the file name without .gz when printing the last output to the console.

