### PR TITLE
Refactor path usage and mocking

### DIFF
--- a/src/commands/outputMetrics.test.ts
+++ b/src/commands/outputMetrics.test.ts
@@ -11,9 +11,8 @@ vi.mock("fs", async (importOriginal) => {
 });
 describe("outputMetrics", () => {
     describe("writes json into file ", () => {
-        let console: ReturnType<typeof mockConsole>;
         beforeEach(() => {
-            console = mockConsole();
+            mockConsole();
         });
 
         afterAll(() => {

--- a/src/parser/Configuration.ts
+++ b/src/parser/Configuration.ts
@@ -35,12 +35,6 @@ export interface ConfigurationParams {
      * Whether to include the relative file paths or absolute paths of the analyzed files in the output.
      */
     relativePaths: boolean;
-    /**
-     * Whether to replace all forward slashes in file paths by backward slashes
-     * in the output.
-     * FOR PLATFORM-INDEPENDENT TESTING PURPOSES ONLY: this option should not be exposed to the user.
-     */
-    enforceBackwardSlash?: boolean;
 }
 
 /**
@@ -88,12 +82,6 @@ export class Configuration {
     readonly relativePaths: boolean;
 
     /**
-     * Whether to replace all forward slashes in file paths by backward slashes in the output.
-     * FOR PLATFORM-INDEPENDENT TESTING PURPOSES ONLY: this option should not be exposed to the user.
-     */
-    readonly enforceBackwardSlash: boolean;
-
-    /**
      * Constructs a new {@link Configuration} object by specifying the configuration options passed by the user
      * as command line arguments.
      * @param parameters {@link Parameters} object containing the configuration options.
@@ -121,15 +109,5 @@ export class Configuration {
 
         this.compress = parameters.compress;
         this.relativePaths = parameters.relativePaths;
-        this.enforceBackwardSlash =
-            parameters.enforceBackwardSlash === undefined ? false : parameters.enforceBackwardSlash;
-    }
-
-    /**
-     * Checks if there is a need to format the file paths with {@link formatPrintPath} before outputting them.
-     * @return Whether there is a need to format the file paths.
-     */
-    needsPrintPathFormatting(): boolean {
-        return this.relativePaths || this.enforceBackwardSlash;
     }
 }

--- a/src/parser/helper/Helper.ts
+++ b/src/parser/helper/Helper.ts
@@ -24,47 +24,24 @@ export function formatCaptures(tree, captures) {
     });
 }
 
-export function replaceForwardWithBackwardSlashes(path: string) {
-    return path.replace(/\//g, "\\");
-}
-
 /**
  * Formats the specified file path for being output in the way it is configured for this parser run.
  * @param filePath The file path.
  * @param config The configuration for this parser run.
- * @param pathModule ONLY FOR TESTING PURPOSES: overrides the platform-specific path module.
  */
-export function formatPrintPath(
-    filePath: string,
-    config: Configuration,
-    pathModule = path,
-): string {
+export function formatPrintPath(filePath: string, config: Configuration): string {
     let result = filePath;
     if (config.relativePaths) {
         // Return the file path relative to the specified base directory, or the name of the file,
         // if the base path points to this single file.
-        result = pathModule.relative(config.sourcesPath, filePath);
+        result = path.relative(config.sourcesPath, filePath);
         if (result.length === 0) {
             // The path specified by the user points to a single file,
             // so return the name of the file as path to print.
-            result = pathModule.basename(filePath);
+            result = path.basename(filePath);
         }
     }
-    if (config.enforceBackwardSlash) {
-        result = replaceForwardWithBackwardSlashes(result);
-    }
     return result;
-}
-
-/**
- * Checks if there is a file extension in the specified path.
- * If so, this function returns the file extension.
- *
- * @param filePath Path that should be checked.
- * @return The file extension (or empty string).
- */
-export function getFileExtension(filePath: string): string {
-    return filePath.match(/\.(?<extension>\w*)$/i)?.groups?.extension ?? "";
 }
 
 /**

--- a/src/parser/helper/Language.test.ts
+++ b/src/parser/helper/Language.test.ts
@@ -1,21 +1,24 @@
 import { describe, expect, it } from "vitest";
 import { assumeLanguageFromFilePath, Language } from "./Language.js";
-import { getTestConfiguration } from "../../../test/metric-end-results/TestHelper.js";
-import path from "path";
+import {
+    getTestConfiguration,
+    mockPosixPath,
+    mockWin32Path,
+} from "../../../test/metric-end-results/TestHelper.js";
 
 describe("assumeLanguageFromFilePath(...)", () => {
     it("should extract the language from a supported file extension in UNIX-Style paths", () => {
         const filePath = "/path/to/the/File.java";
         const config = getTestConfiguration(filePath);
 
-        expect(assumeLanguageFromFilePath(filePath, config, path.posix)).toBe(Language.Java);
+        expect(assumeLanguageFromFilePath(filePath, config)).toBe(Language.Java);
     });
 
     it("should extract the language from a supported file extension in DOS-Style paths", () => {
         const filePath = "C:\\users\\user\\documents\\File.java";
         const config = getTestConfiguration(filePath);
 
-        expect(assumeLanguageFromFilePath(filePath, config, path.win32)).toBe(Language.Java);
+        expect(assumeLanguageFromFilePath(filePath, config)).toBe(Language.Java);
     });
 
     it("should treat .h files as C++ per default", () => {
@@ -33,54 +36,60 @@ describe("assumeLanguageFromFilePath(...)", () => {
     });
 
     it("should treat a .h file as C if it lies in a folder specified in the configuration (DOS-style)", () => {
+        mockWin32Path();
         const filePath = "C:\\users\\user\\code\\folder-for-c\\sub-folder\\File.h";
         const config = getTestConfiguration("C:\\users\\user\\code", {
             parseSomeHAsC: "folder-for-c",
         });
 
-        expect(assumeLanguageFromFilePath(filePath, config, path.win32)).toBe(Language.C);
+        expect(assumeLanguageFromFilePath(filePath, config)).toBe(Language.C);
     });
 
     it("should treat a .h file as C if it lies in a folder specified in the configuration (UNIX-style)", () => {
+        mockPosixPath();
         const filePath = "/path/to/the/code/sub-folder/folder-for-c/sub-folder/File.h";
         const config = getTestConfiguration("/path/to/the/code", { parseSomeHAsC: "folder-for-c" });
 
-        expect(assumeLanguageFromFilePath(filePath, config, path.posix)).toBe(Language.C);
+        expect(assumeLanguageFromFilePath(filePath, config)).toBe(Language.C);
     });
 
     it("should treat a .h file as C++ if it lies outside of folders specified in the configuration (DOS-style)", () => {
+        mockWin32Path();
         const filePath = "C:\\users\\user\\code\\folder-for-c++\\sub-folder\\File.h";
         const config = getTestConfiguration("C:\\users\\user\\code", {
             parseSomeHAsC: "folder-for-c, c-file.h",
         });
 
-        expect(assumeLanguageFromFilePath(filePath, config, path.win32)).toBe(Language.CPlusPlus);
+        expect(assumeLanguageFromFilePath(filePath, config)).toBe(Language.CPlusPlus);
     });
 
     it("should treat a .h file as C++ if it lies in outside of folders specified in the configuration (UNIX-style)", () => {
+        mockPosixPath();
         const filePath = "/path/to/the/code/sub-folder/folder-for-c++/sub-folder/File.h";
         const config = getTestConfiguration("/path/to/the/code", {
             parseSomeHAsC: "folder-for-c, c-file.h",
         });
 
-        expect(assumeLanguageFromFilePath(filePath, config, path.posix)).toBe(Language.CPlusPlus);
+        expect(assumeLanguageFromFilePath(filePath, config)).toBe(Language.CPlusPlus);
     });
 
     it("should treat a .h file as C if it has a name specified in the configuration (DOS-style)", () => {
+        mockWin32Path();
         const filePath = "C:\\users\\user\\code\\folder-for-c++\\sub-folder\\c-file.h";
         const config = getTestConfiguration("C:\\users\\user\\code", {
             parseSomeHAsC: "folder-for-c, c-file.h",
         });
 
-        expect(assumeLanguageFromFilePath(filePath, config, path.win32)).toBe(Language.C);
+        expect(assumeLanguageFromFilePath(filePath, config)).toBe(Language.C);
     });
 
     it("should treat a .h file as C if it has a name specified in the configuration (UNIX-style)", () => {
+        mockPosixPath();
         const filePath = "/path/to/the/code/sub-folder/folder-for-c++/sub-folder/c-file.h";
         const config = getTestConfiguration("/path/to/the/code", {
             parseSomeHAsC: "folder-for-c, c-file.h",
         });
 
-        expect(assumeLanguageFromFilePath(filePath, config, path.posix)).toBe(Language.C);
+        expect(assumeLanguageFromFilePath(filePath, config)).toBe(Language.C);
     });
 });

--- a/src/parser/metrics/coupling/Coupling.ts
+++ b/src/parser/metrics/coupling/Coupling.ts
@@ -248,7 +248,7 @@ export class Coupling implements CouplingMetric {
         relationships: Relationship[],
         couplingMetrics: Map<string, CouplingMetrics>,
     ): CouplingResult {
-        if (this.config.needsPrintPathFormatting()) {
+        if (this.config.relativePaths) {
             for (const relationship of relationships) {
                 relationship.fromSource = formatPrintPath(relationship.fromSource, this.config);
                 relationship.toSource = formatPrintPath(relationship.toSource, this.config);

--- a/test/metric-end-results/CSharpMetrics.test.ts
+++ b/test/metric-end-results/CSharpMetrics.test.ts
@@ -3,6 +3,7 @@ import {
     expectFileMetric,
     getCouplingMetrics,
     mockConsole,
+    mockWin32Path,
     parseAllFileMetrics,
 } from "./TestHelper.js";
 import { FileMetric, FileMetricResults } from "../../src/parser/metrics/Metric.js";
@@ -24,6 +25,7 @@ describe("C# metric tests", () => {
     describe("parsing C# dependencies", () => {
         it("should calculate the right dependencies and coupling metrics", async () => {
             mockConsole();
+            mockWin32Path({ skip: ["join", "resolve", "normalize"] });
             const couplingResult = await getCouplingMetrics(
                 csharpTestResourcesPath + "coupling-examples/",
             );

--- a/test/metric-end-results/PHPMetrics.test.ts
+++ b/test/metric-end-results/PHPMetrics.test.ts
@@ -3,6 +3,7 @@ import {
     expectFileMetric,
     getCouplingMetrics,
     mockConsole,
+    mockWin32Path,
     parseAllFileMetrics,
 } from "./TestHelper.js";
 import { FileMetric, FileMetricResults } from "../../src/parser/metrics/Metric.js";
@@ -124,6 +125,7 @@ describe("PHP metrics tests", () => {
     describe("parsing PHP dependencies", () => {
         it("should calculate the right dependencies and coupling metrics", async () => {
             mockConsole();
+            mockWin32Path({ skip: ["join", "resolve", "normalize"] });
             const couplingResult = await getCouplingMetrics(
                 phpTestResourcesPath + "coupling-examples/",
             );

--- a/test/metric-end-results/TestHelper.ts
+++ b/test/metric-end-results/TestHelper.ts
@@ -47,7 +47,6 @@ function mockPath(platformPath: PlatformPath, skip: (keyof PlatformPath)[] = [])
         if (skip.includes(key as any)) {
             continue;
         }
-        console.log(key);
         if (typeof value === "function") {
             vi.spyOn(path, key as any).mockImplementation(value);
         } else if (typeof value === "string") {


### PR DESCRIPTION
# Refactor path usage and mocking

Closes: #302

Note: #300 should be reviewed and merged first. This PR depends on it to prevent merge conflicts.

## Description

- path is never included in function signatures for test purposes => use mocking instead
- deleted unnecessary helper functions
- made mocking test helpers more comprehensive
