### PR TITLE
Enhance JS documentation and count static initialization block for JS, TS and TSX

### DIFF
--- a/docs/JavaScript.md
+++ b/docs/JavaScript.md
@@ -23,6 +23,7 @@ It does **not** count:
 
 The "functions" metric counts:
 
+-   static initialization blocks
 -   function declarations and expressions with `function`,`function*`, `async function` and `async function*`
 -   constructors, getter (`get <method_name>`), setter (`set <method_name>`), and methods of classes and objects
 -   arrow functions

--- a/docs/JavaScript.md
+++ b/docs/JavaScript.md
@@ -30,7 +30,11 @@ The "functions" metric counts:
 
 It does **not** count:
 
--   functions created with the constructors: `Function()`, `GeneratorFunction()`, `AsyncFunction()`, `AsyncGeneratorFunction()`
+-   functions created from the constructors `new Function()`, `new GeneratorFunction()`, `new AsyncFunction()` and `new AsyncGeneratorFunction()`. Ex:
+    ```
+    const generator = new GeneratorFunction("a", "yield a * 2"); //we don't count this as function
+    const iterator = generator(10);
+    ```
 
 ### classes
 

--- a/docs/TS_TSX.md
+++ b/docs/TS_TSX.md
@@ -23,6 +23,7 @@ It does **not** count:
 
 The "functions" metric counts:
 
+-   static initialization blocks
 -   method declarations in classes, abstract classes and interfaces
 -   static methods, constructors, getters and setters
 -   functions declared with the keyword `function`

--- a/path.json
+++ b/path.json
@@ -1,0 +1,1 @@
+{"nodes":[{"name":"C:\\Programmieren\\metric-gardener\\resources\\javascript\\static-initialization-block.js","type":"source_code","metrics":{"complexity":0,"functions":0,"classes":1,"lines_of_code":7,"comment_lines":0,"real_lines_of_code":6,"keywords_in_comments":0}}],"info":[],"relationships":[]}

--- a/path.json
+++ b/path.json
@@ -1,1 +1,0 @@
-{"nodes":[{"name":"C:\\Programmieren\\metric-gardener\\resources\\javascript\\static-initialization-block.js","type":"source_code","metrics":{"complexity":0,"functions":0,"classes":1,"lines_of_code":7,"comment_lines":0,"real_lines_of_code":6,"keywords_in_comments":0}}],"info":[],"relationships":[]}

--- a/resources/javascript/static-initialization-block.js
+++ b/resources/javascript/static-initialization-block.js
@@ -1,0 +1,6 @@
+class ClassWithStaticInitializationBlock {
+    static staticProperty2;
+    static {
+        this.staticProperty2 = 'Property 2';
+    }
+}

--- a/resources/typescript/static_init_block.ts
+++ b/resources/typescript/static_init_block.ts
@@ -1,0 +1,5 @@
+class Foo {
+    // This is a static block:
+    static {
+    }
+}

--- a/src/parser/config/node-types-config.json
+++ b/src/parser/config/node-types-config.json
@@ -7274,7 +7274,7 @@
     },
     {
         "type_name": "class_static_block",
-        "category": "",
+        "category": "function",
         "languages": [
             "js",
             "ts",

--- a/test/metric-end-results/java-script-metrics.test.ts
+++ b/test/metric-end-results/java-script-metrics.test.ts
@@ -59,6 +59,9 @@ describe("JavaScript metrics tests", () => {
         it("should count all methods in object definition", () => {
             testFileMetric("object-method.js", "functions", 4);
         });
+        it("should count static initialization block", () => {
+            testFileMetric("static-initialization-block.js", "functions", 1);
+        });
     });
 
     describe("parses JavaScript comment lines metric", () => {

--- a/test/metric-end-results/type-script-metrics.test.ts
+++ b/test/metric-end-results/type-script-metrics.test.ts
@@ -56,6 +56,9 @@ describe("TypeScript metrics tests", () => {
         it("should count functions and methods properly", () => {
             testFileMetric("functions-and-methods.ts", "functions", 9);
         });
+        it("should count static initialization block", () => {
+            testFileMetric("static_init_block.ts", "functions", 1);
+        });
     });
 
     describe("parses TypeScript comment lines metric", () => {


### PR DESCRIPTION
# Enhance JS documentation and count static initialization block for JS, TS and TSX
Closes #337
Closes #240

## Description

- The static initialization block is counted towards both the 'functions' and 'complexity' metrics, just like in other languages.
- make JS documentation more precise by adding example for "functions" metric

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:

-   [x] There are automated tests for newly written code and bug fixes
-   [x] Documentation ([README.md](https://github.com/MaibornWolff/metric-gardener/blob/main/README.md), [UPDATE_GRAMMARS.md](https://github.com/MaibornWolff/metric-gardener/blob/main/docs/UPDATE_GRAMMARS.md)) has been updated
