### PR TITLE
Fix/212/method signatures not counted

### DIFF
--- a/docs/TS_TSX.md
+++ b/docs/TS_TSX.md
@@ -28,6 +28,7 @@ The "functions" metric counts:
 -   static methods, constructors, getters and setters
 -   functions declared with the keyword `function`
 -   arrow functions
+-   interface/abstract methods (signatures)
 
 ### classes
 

--- a/resources/typescript/classes.ts
+++ b/resources/typescript/classes.ts
@@ -3,3 +3,13 @@ class Test1 {}
 class Test2 {}
 
 class Test3 {}
+
+abstract class Animal {
+    constructor(protected name: string) { }
+
+    // abstract_method_signature
+    abstract makeSound(input : string) : string;
+
+    move(meters) {
+    }
+}

--- a/resources/typescript/classes.ts
+++ b/resources/typescript/classes.ts
@@ -4,12 +4,4 @@ class Test2 {}
 
 class Test3 {}
 
-abstract class Animal {
-    constructor(protected name: string) { }
-
-    // abstract_method_signature
-    abstract makeSound(input : string) : string;
-
-    move(meters) {
-    }
-}
+abstract class Test4 {}

--- a/resources/typescript/functions-and-methods.ts
+++ b/resources/typescript/functions-and-methods.ts
@@ -28,8 +28,10 @@ const myFunction = function myFunctionDefinition() {
 
 const x = (x, y) => x * y;
 
-// method_signature
 interface KeyValueProcessor{ functionName(key: number, value: string): void; }
 
-// call_signature
 interface KeyValueProcessor{ (key: number, value: string): void; };
+
+abstract class Animal {
+    abstract makeSound(input : string) : string;
+}

--- a/resources/typescript/functions-and-methods.ts
+++ b/resources/typescript/functions-and-methods.ts
@@ -27,3 +27,9 @@ const myFunction = function myFunctionDefinition() {
 };
 
 const x = (x, y) => x * y;
+
+// method_signature
+interface KeyValueProcessor{ functionName(key: number, value: string): void; }
+
+// call_signature
+interface KeyValueProcessor{ (key: number, value: string): void; };

--- a/src/parser/config/node-types-config.json
+++ b/src/parser/config/node-types-config.json
@@ -5422,7 +5422,7 @@
     },
     {
         "type_name": "abstract_method_signature",
-        "category": "",
+        "category": "function",
         "languages": [
             "ts",
             "tsx"
@@ -5446,7 +5446,7 @@
     },
     {
         "type_name": "call_signature",
-        "category": "",
+        "category": "function",
         "languages": [
             "ts",
             "tsx"
@@ -5551,7 +5551,7 @@
     },
     {
         "type_name": "method_signature",
-        "category": "",
+        "category": "function",
         "languages": [
             "ts",
             "tsx"

--- a/test/metric-end-results/type-script-metrics.test.ts
+++ b/test/metric-end-results/type-script-metrics.test.ts
@@ -22,7 +22,7 @@ describe("TypeScript metrics tests", () => {
         });
 
         it("should count functions and methods correctly", () => {
-            testFileMetric("functions-and-methods.ts", "complexity", 9);
+            testFileMetric("functions-and-methods.ts", "complexity", 12);
         });
 
         it("should not count multiple return statements within functions and methods correctly", () => {
@@ -48,13 +48,13 @@ describe("TypeScript metrics tests", () => {
 
     describe("parses TypeScript classes metric", () => {
         it("should count class declarations", () => {
-            testFileMetric("classes.ts", "classes", 3);
+            testFileMetric("classes.ts", "classes", 4);
         });
     });
 
     describe("parses TypeScript functions metric", () => {
         it("should count functions and methods properly", () => {
-            testFileMetric("functions-and-methods.ts", "functions", 9);
+            testFileMetric("functions-and-methods.ts", "functions", 12);
         });
         it("should count static initialization block", () => {
             testFileMetric("static_init_block.ts", "functions", 1);


### PR DESCRIPTION
# Fix missing node types to include interface and abstract methods as functions in typescript and tsx

Closes: #212

## Description

-   As of now, interface methods and abstract methods were not counted as functions in typescript and tsx but they should be
-   Add types in `node-types-config.json`

## Definition of Done

A PR is only ready for merge once all the following acceptance criteria are fulfilled:

-   [x] All TODOs related to this PR have been closed
-   [x] There are automated tests for newly written code and bug fixes
-   [x] Documentation ([README.md](https://github.com/MaibornWolff/metric-gardener/blob/main/README.md), [UPDATE_GRAMMARS.md](https://github.com/MaibornWolff/metric-gardener/blob/main/docs/UPDATE_GRAMMARS.md)) has been updated
